### PR TITLE
Blogpost & events 624

### DIFF
--- a/_data/blog_posts.yml
+++ b/_data/blog_posts.yml
@@ -1,19 +1,19 @@
+- title: "Community Spotlight: How Topol Makes Creating Beautiful HTML Email Templates Easy"
+  url: https://www.sparkpost.com/blog/topol-html-email-templates/
+  order: 1
+
 - title: "Running Your First Technical Workshop: The 'I Have No Idea What I'm Doing' Edition"
   url: https://www.sparkpost.com/blog/running-technical-workshop/
-  order: 1
+  order: 2
 
 - title: "Introducing Our SendGrid Template Migration Tool"
   url: https://www.sparkpost.com/blog/sendgrid-template-migration-tool/
-  order: 2
+  order: 3
 
 - title: "DEVintersection: Let's Talk APIs, Swag and Mouse Ears"
   url: https://www.sparkpost.com/blog/devintersection-apis-mouse-ears/
-  order: 3
+  order: 4
 
 - title: "Operating DNS on the AWS Network: Challenges and Lessons"
   url: https://www.sparkpost.com/blog/dns-aws-network-lessons/
-  order: 4
-
-- title: "Product Announcement: Webhooks by Subaccount and Multiple Bounce Domains"
-  url: https://www.sparkpost.com/blog/webhooks-by-subaccount-bounce-domains/
   order: 5

--- a/_data/events.yml
+++ b/_data/events.yml
@@ -1,3 +1,9 @@
+- name: "SFHTML5"
+  type: past
+  url: https://www.meetup.com/sfhtml5/events/238957406/
+  date_start: 2017-07-28
+  location: San Francisco, CA
+
 - name: "WaffleJS"
   type: future
   url: https://wafflejs.com/
@@ -26,20 +32,20 @@
   location: New York, NY
 
 - name: "SFHTML5"
-  type: future
+  type: past
   url: https://www.meetup.com/sfhtml5/events/238957406/
   date_start: 2017-06-23
   location: San Francisco, CA
 
 - name: "O'Reilly Fluent Conference"
-  type: future
+  type: past
   url: http://conferences.oreilly.com/fluent/fl-ca
   date_start: 2017-06-19
   date_end: 2017-06-22
   location: San Jose, CA
   
 - name: "O'Reilly Velocity Conference"
-  type: future
+  type: past
   url: http://conferences.oreilly.com/velocity/vl-ca
   date_start: 2017-06-19
   date_end: 2017-06-22


### PR DESCRIPTION
- added Topol blogpost
- changed status of Fluent, Velocity, & June SFHTML5
- added July SFHTML5 with "past" status to hide it until meetup.com event is live