### PR TITLE
Allow Parameters to be used anywhere in the Transition description

### DIFF
--- a/plugins/gatsby-transformer-api-blueprint/data-structures.js
+++ b/plugins/gatsby-transformer-api-blueprint/data-structures.js
@@ -18,7 +18,7 @@ function stringify(node) {
 }
 
 /**
- * get all data structures from code blocks with the language "attributes"
+ * get all data structures from lists that start with  "Data Structure"
  */
 function gatherDataStructures(tree) {
   let dataStructures = []

--- a/plugins/gatsby-transformer-api-blueprint/extend-node-type.js
+++ b/plugins/gatsby-transformer-api-blueprint/extend-node-type.js
@@ -92,7 +92,6 @@ module.exports = async ({ type }) => {
     ast: {
       type: GraphQLJSON,
       async resolve(node) {
-        try {
         let tree = parseMarkdown(node.internal.content)
         const dataStructures = gatherDataStructures(tree)
         tree = replaceDataStructures(tree, dataStructures)
@@ -104,10 +103,6 @@ module.exports = async ({ type }) => {
         const ast = await parseApiBlueprint(markdown)
 
         return minim.toRefract(ast)
-        }
-        catch (e) {
-          console.log(e)
-        }
       }
     },
     TableOfContents: {

--- a/plugins/gatsby-transformer-api-blueprint/extend-node-type.js
+++ b/plugins/gatsby-transformer-api-blueprint/extend-node-type.js
@@ -6,6 +6,7 @@ const remarkParse = require('remark-parse')
 const remarkStringify = require('remark-stringify')
 const slugify = require('../../src/utils/api/slugify')
 const { gatherDataStructures, replaceDataStructures, insertDataStructures } = require('./data-structures')
+const { insertParametersTag, moveParametersList } = require('./parameters')
 
 const parseProcessor = unified().use(remarkParse)
 const parseMarkdown = parseProcessor.parse
@@ -91,15 +92,22 @@ module.exports = async ({ type }) => {
     ast: {
       type: GraphQLJSON,
       async resolve(node) {
+        try {
         let tree = parseMarkdown(node.internal.content)
         const dataStructures = gatherDataStructures(tree)
         tree = replaceDataStructures(tree, dataStructures)
         tree = insertDataStructures(tree, dataStructures)
+        tree = insertParametersTag(tree)
+        tree = moveParametersList(tree)
         const markdown = stringifyMarkdown(tree)
 
         const ast = await parseApiBlueprint(markdown)
 
         return minim.toRefract(ast)
+        }
+        catch (e) {
+          console.log(e)
+        }
       }
     },
     TableOfContents: {

--- a/plugins/gatsby-transformer-api-blueprint/parameters.js
+++ b/plugins/gatsby-transformer-api-blueprint/parameters.js
@@ -1,0 +1,92 @@
+const crypto = require('crypto')
+const visit = require('unist-util-visit')
+const modify = require('unist-util-modify-children')
+const removePosition = require('unist-util-remove-position')
+const flatten = require('lodash.flatten')
+const unified = require('unified')
+const remarkParse = require('remark-parse')
+
+const parseProcessor = unified().use(remarkParse)
+const parseMarkdown = parseProcessor.parse
+
+/**
+ * inserts html parameter tags before all lists that start with Parameters
+ */
+function insertParametersTag(tree) {
+  modify((node, index, parent) => {
+    if (isParametersList(node)) {
+      parent.children.splice(index, 0, {
+        "type": "paragraph",
+        "children": [
+          { "type": "html", "value": "<parameters>" },
+          { "type": "html", "value": "</parameters>" }
+        ]
+      })
+    }
+
+    // skip this node so we don't get stuck in an infinite loop
+    return index + 2
+  })(tree)
+
+  return tree
+}
+
+/**
+ * inserts html parameter tags before all lists that start with Parameters
+ */
+function moveParametersList(tree) {
+  modify((node, nodeIndex, parent) => {
+
+    if (isParametersList(node)) {
+      // remove Parameters list
+      parent.children.splice(nodeIndex, 1)
+
+
+      // find next Request list
+      const requestIndex = parent.children.findIndex((node, index) => {
+        if (node.type !== 'list') {
+          return false
+        }
+
+        if (index < nodeIndex) {
+          return false
+        }
+
+        const text = node.children[0].children[0].children[0].value
+
+        return text && text.startsWith('Request')
+      })
+
+      // insert parameters list right before the request
+      parent.children.splice(requestIndex, 0, node)
+    }
+
+    // skip this node so we don't get stuck in an infinite loop
+    // return nodeIndex+1
+  })(tree)
+
+  return tree
+}
+
+const parametersPattern = /^\s*Parameters\s*/i
+/** checks if a node is a parameters list */
+function isParametersList(node) {
+  // we have a list...
+  if(node.type !== 'list')
+    return false
+
+  // with 1 item
+  if (node.children.length !== 1)
+    return false
+
+  const listItem = node.children[0]
+
+  const paragraph = listItem.children[0]
+  const text = paragraph.children[0]
+
+  // that matches our data structure heading
+  return text.type === 'text' && parametersPattern.test(text.value)
+}
+
+
+module.exports = { insertParametersTag, moveParametersList }

--- a/src/components/api/components/BlockMarkdown.js
+++ b/src/components/api/components/BlockMarkdown.js
@@ -114,6 +114,7 @@ const components = {
       }}
     </Context.Consumer>
   ),
+  parameters() {},
 }
 
 const componentNames = toArray(components).map(c => c.name)
@@ -122,13 +123,28 @@ const hasComponent = props =>
     React.Children.map(
       props.children,
       component =>
-        component.type &&
-        componentNames.includes(
-          component.type.displayName || component.type.name
-        )
+        component.type && componentNames.includes(component.type.displayName)
     ) || []
   ).includes(true)
 
-const BlockMarkdown = props => <Markdown components={components} {...props} />
+const BlockMarkdown = ({ parameters, ...props }) => {
+  return (
+    <Markdown
+      components={{
+        ...components,
+        parameters() {
+          return (
+            <DataStructure
+              title="Parameters"
+              isParameter={true}
+              dataStructure={{ content: parameters }}
+            />
+          )
+        },
+      }}
+      {...props}
+    />
+  )
+}
 
 export default BlockMarkdown

--- a/src/components/api/parts/Transition.js
+++ b/src/components/api/parts/Transition.js
@@ -47,16 +47,6 @@ const Href = styled.span`
   color: ${grayscale(4)};
 `
 
-function Parameters({ parameters }) {
-  return (
-    <DataStructure
-      title="Parameters"
-      isParameter={true}
-      dataStructure={{ content: parameters }}
-    />
-  )
-}
-
 function Attributes({ attributes }) {
   return <DataStructure title="Request Body" dataStructure={attributes} />
 }
@@ -106,9 +96,8 @@ export default function Transition({
             <Href>{`/api/${version}${href}`}</Href>
           </HrefWrapper>
         </div>
-        {parameters && <Parameters parameters={parameters} />}
         {attributes && <Attributes attributes={attributes} />}
-        {copy && <BlockMarkdown>{copy}</BlockMarkdown>}
+        {copy && <BlockMarkdown parameters={parameters}>{copy}</BlockMarkdown>}
       </Wrapper>
     </Debug>
   )


### PR DESCRIPTION
Right now we can use Data Structures anywhere in the API Blueprint files and we want to be able to do the same with Parameters. Parameters right now always render at the top and have to be listed as the last element before the Request.

##### Right now 
```

### Delete a Relay Webhook [DELETE /relay-webhooks/{id}]

Delete a relay webhook by specifying the webhook ID in the URI path.

+ Parameters
    + id (required, string, `12013026328707075`)
+ Request
    etc....
```

This PR should allow us to put the Parameters anywhere.

##### End goal
```

### Delete a Relay Webhook [DELETE /relay-webhooks/{id}]

Check out these parameters:

+ Parameters
    + id (required, string, `12013026328707075`)

Delete a relay webhook by specifying the webhook ID in the URI path.

+ Request
    etc....
```
