### PR TITLE
TR-371 Add new responses from TR-93

### DIFF
--- a/content/api/transmissions.apib
+++ b/content/api/transmissions.apib
@@ -582,6 +582,18 @@ Only transmissions which are scheduled for future generation may be deleted.
 
 + Response 204
 
++ Response 400 (application/json)
+
+        {
+            "errors": [
+                {
+                    "message": "invalid params",
+                    "code": "1200",
+                    "description": "Cannot cancel by transmission_id, only cancel by campaign_id is supported"
+                }
+            ]
+        }
+
 + Response 404 (application/json)
 
         {
@@ -630,6 +642,18 @@ Delete all transmissions in a campaign.
 + Request
 
 + Response 204
+
++ Response 400 (application/json)
+
+        {
+            "errors": [
+                {
+                    "message": "invalid params",
+                    "code": "1200",
+                    "description": "Cannot cancel by campaign_id, only cancel by transmission_id is supported"
+                }
+            ]
+        }
 
 ### List All Scheduled Transmissions [GET /transmissions{?campaign_id,template_id}]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -917,9 +917,9 @@
       "integrity": "sha512-DUioEWBd0NG30G1/wI0amNN/sSJ/xuX4/YWm4nNa+bUU6swuS7CF+sH/nifu+SPy5BFqRzQEyEWvi9zIDVP+Lw=="
     },
     "@types/react": {
-      "version": "16.4.6",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.4.6.tgz",
-      "integrity": "sha512-9LDZdhsuKSc+DjY65SjBkA958oBWcTWSVWAd2cD9XqKBjhGw1KzAkRhWRw2eIsXvaIE/TOTjjKMFVC+JA1iU4g==",
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.4.7.tgz",
+      "integrity": "sha512-tHpSs7HMyjnpyfzka1G0pYh7rBNdpwGgcIDT4vfV6jUaR69yOHo/vNH2H+d9iYHo9xnX4qDe7UalPe9HiGRkLw==",
       "requires": {
         "csstype": "^2.2.0"
       }
@@ -5979,9 +5979,9 @@
       "integrity": "sha1-THbsL/CsGjap3M+aAN+GIweNTtg="
     },
     "gatsby": {
-      "version": "2.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.0.0-beta.55.tgz",
-      "integrity": "sha1-/1hncRZUzTt3apYoNuH2rcr/lkY=",
+      "version": "2.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.0.0-beta.56.tgz",
+      "integrity": "sha1-hoiYTiM3iOI1D1wacRGim62/V1s=",
       "requires": {
         "@babel/code-frame": "7.0.0-beta.52",
         "@babel/core": "7.0.0-beta.52",
@@ -7047,11 +7047,12 @@
       "integrity": "sha1-1oFebt1hjoeNXZIcE/xmAz7IZ+I="
     },
     "graphql-request": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-1.6.0.tgz",
-      "integrity": "sha512-qqAPLZuaGlwZDsMQ2FfgEyZMcXFMsPPDl6bQQlmwP/xCnk1TqxkE1S644LsHTXAHYPvmRWsIimfdcnys5+o+fQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-1.7.0.tgz",
+      "integrity": "sha512-9Auw7y8WFmiVxW7FcJFvG5/br/P/nFNlWNVTddk8R+Mc/7jfWzXKtUUc+t7P9gAcVC7DkntUlqVdGjR/njbPlQ==",
       "requires": {
-        "cross-fetch": "2.0.0"
+        "cross-fetch": "2.0.0",
+        "graphql": "^0.13.2"
       }
     },
     "graphql-skip-limit": {
@@ -14555,9 +14556,9 @@
       "integrity": "sha512-II+n2ms4mPxK+RnIxRPOw3zwF2jRscdJIUE9BfkKHm4FYEg9+biIoTMnaZF5MpemE3T+VhMLrhbyD4ilkPCSbg=="
     },
     "webpack": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.16.1.tgz",
-      "integrity": "sha512-6jpzObU18y7lXDJz7XCLvzgrqcJ0rZ2jhKvnTivza9gM2GvPW93xxtmEll2GgmdC0zVQAtbHrH/9BtyMjSDZfA==",
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.16.2.tgz",
+      "integrity": "sha512-Fw+RtyJD9ekQ6Mh6e/hYeoafIKK6bP6qS7EVnZ3hejt+1Ah3JCJZTGE0e5S6Eq4ijIVht6ktWOEqJfm92+5MLw==",
       "requires": {
         "@webassemblyjs/ast": "1.5.13",
         "@webassemblyjs/helper-module-context": "1.5.13",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "escape-string-regexp": "^1.0.5",
     "extract-text-webpack-plugin": "^3.0.2",
     "font-awesome": "^4.7.0",
-    "gatsby": "^2.0.0-beta.55",
+    "gatsby": "^2.0.0-beta.56",
     "gatsby-plugin-google-tagmanager": "^2.0.0-beta.1",
     "gatsby-plugin-lodash": "^3.0.1-beta.1",
     "gatsby-plugin-netlify": "^2.0.0-beta.3",


### PR DESCRIPTION
In [TR-93](https://jira.int.messagesystems.com/browse/TR-93), we added new responses to "Delete a Scheduled Transmission" and "Delete Scheduled Transmissions By Campaign ID".

When a customer tries to cancel by campaign_id with scheduled send disabled, the API now responds with a 400 error saying "Cannot cancel by campaign_id, only cancel by transmission_id is supported".

When a customer tries to cancel by transmission_id with scheduled send enabled, the API now responds with a 400 error saying "Cannot cancel by transmission_id, only cancel by campaign_id is supported".

This should be merged in once TR-93 hits production.