### PR TITLE
Update message events samples endpoint responses to be more generic

### DIFF
--- a/content/api/message-events.apib
+++ b/content/api/message-events.apib
@@ -134,10 +134,6 @@ Returns a list of descriptions of the event fields that could be included in a r
             "description": "Type of event this record describes",
             "sampleValue": "bounce"
           },
-          "bounce_class": {
-            "description": "Classification code for a given message (see [Bounce Classification Codes](https://support.sparkpost.com/customer/portal/articles/1929896))",
-            "sampleValue": "1"
-          },
           ...
         },
         ...
@@ -167,8 +163,6 @@ Returns an example message event for each event type listed in the `events` para
       "results": [
         {
           "type": "bounce",
-          "bounce_class": "1",
-          "campaign_id": "Example Campaign Name",
           ...
         }
       ]


### PR DESCRIPTION
This puts it more inline with the webhooks samples endpoints, and also eliminates the possibility of these docs becoming out of date as event sample docs changes