### PR TITLE
Fix Markdown-only navigation

### DIFF
--- a/plugins/gatsby-transformer-api-blueprint/data-structures.js
+++ b/plugins/gatsby-transformer-api-blueprint/data-structures.js
@@ -2,7 +2,7 @@ const crypto = require('crypto')
 const visit = require('unist-util-visit')
 const modify = require('unist-util-modify-children')
 const removePosition = require('unist-util-remove-position')
-const flatten = require('lodash.flatten')
+const { flatten } = require('lodash')
 const unified = require('unified')
 const remarkParse = require('remark-parse')
 

--- a/plugins/gatsby-transformer-api-blueprint/extend-node-type.js
+++ b/plugins/gatsby-transformer-api-blueprint/extend-node-type.js
@@ -1,5 +1,5 @@
 const { GraphQLJSON } = require('gatsby/graphql')
-const flatMapDeep = require('lodash/flatmapdeep')
+const { flatMapDeep } = require('lodash')
 const parseApiBlueprint = require('./parse-api-blueprint')
 const minim = require('minim').namespace()
 const unified = require('unified')

--- a/plugins/gatsby-transformer-api-blueprint/package-lock.json
+++ b/plugins/gatsby-transformer-api-blueprint/package-lock.json
@@ -173,11 +173,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
-    "lodash.flatten": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
-    },
     "longest-streak": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.2.tgz",

--- a/plugins/gatsby-transformer-api-blueprint/package.json
+++ b/plugins/gatsby-transformer-api-blueprint/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "fury": "^3.0.0-beta.6",
     "fury-adapter-apib-parser": "^0.10.0",
-    "lodash.flatten": "^4.4.0",
+    "lodash": "^4.17.10",
     "mdast-util-toc": "^2.0.1",
     "minim": "^0.20.5",
     "remark": "^9.0.0",


### PR DESCRIPTION
Right now the markdown-only apib files don't have a structured navigation.

This PR adds in that structure so the sidebar is easier to navigate.

**Before**
![screen shot 2018-08-14 at 1 53 05 pm](https://user-images.githubusercontent.com/4924860/44117897-68be4720-9fc9-11e8-85c0-2ecd52d9baae.png)


**After**
![screen shot 2018-08-14 at 2 13 36 pm](https://user-images.githubusercontent.com/4924860/44118854-42fa90cc-9fcc-11e8-83d0-94cd63bfa1d1.png)
