### PR TITLE
Two additional amp-mustache auto escaping exceptions

### DIFF
--- a/content/api/template-language.apib
+++ b/content/api/template-language.apib
@@ -675,7 +675,8 @@ are preserved upon delivery to email clients.
 There are certain expressions that SparkPost will *not* escape.  These include:
 * Expressions that contain the keyword "sparkpost"
 * Expressions that are already a call to one of the curly escape macros: opening_double_curly(), closing_double_curly(), opening_triple_curly(), and closing_triple_curly()
-* Expressions that contain use of "loop_var"
+* Expressions that contain a call to the render_snippet() macro
+* Expressions that contain use of "loop_var" or "loop_index"
 * The "else" and "end" control statements
 
 In the following example, {{name}}, {{price}}, {{#cart_items}}, {{/cart_items}}, and {{^cart_items}} will be automatically


### PR DESCRIPTION
TR-522 adds the render_snippet() macro which won't be auto escaped when seen within amp-mustache templates.

TR-522 also added auto escaping of expressions that contain "loop_index".  This was missed during the original development of the amp-mustache auto escaping.