### PR TITLE
FE-642: publish FE enterprise account options

### DIFF
--- a/content/api/account.apib
+++ b/content/api/account.apib
@@ -30,14 +30,19 @@ Retrieve information regarding your SparkPost account and set account options.
         + type (string) - Type of subscription.
             + Default: default
     + pending_subscription (object) - Details regarding a pending subscription upgrade or downgrade.
-    + options (object) - Account-level tracking settings.
-        + smtp_tracking_default (boolean) - Account-level default for SMTP engagement tracking
-        + rest_tracking_default (boolean) - Account-level default for REST API engagement tracking
-        + transactional_unsub (boolean) - Set to `true` to include `List-Unsubscribe` header for all transactional messages by default
-        + transactional_default (boolean) - Set to `true` to send messages as transactional by default
-        + initial_open_pixel_tracking (boolean) - Account-level default for Initial Open tracking
+    + options (object) - Account-level settings.
+        + allow_anyone_at_domain_verification (boolean) - true if the account can use anyone@ domain verification
+        + allow_default_bounce_domain (boolean) - true if the account can set a default signing domain
+        + allow_default_signing_domains_for_ip_pools (boolean) - true if the account can set a default signing domain on an IP pool
+        + allow_subaccount_default_bounce_domain (boolean) - true if the account can set a default bounce domain on a subaccount
         + click_tracking (boolean)
             Set to `false` to turn off click tracking (overrides smtp_tracking_default and rest_tracking_default)
+        + initial_open_pixel_tracking (boolean) - Account-level default for Initial Open tracking
+        + rest_tracking_default (boolean) - Account-level default for REST API engagement tracking
+        + smtp_tracking_default (boolean) - Account-level default for SMTP engagement tracking
+        + tracking_domain_cname (string) - Account-level tracking domain CNAME record
+        + transactional_default (boolean) - Set to `true` to send messages as transactional by default
+        + transactional_unsub (boolean) - Set to `true` to include `List-Unsubscribe` header for all transactional messages by default
     + usage (object) - Account quota usage details. Specify 'include=usage' in query string to include usage info. Usage data is not available for Enterprise accounts.
         + timestamp (string) - ISO date usage data was retrieved
         + day (object) - Daily usage report.

--- a/content/api/account.apib
+++ b/content/api/account.apib
@@ -31,7 +31,7 @@ Retrieve information regarding your SparkPost account and set account options.
             + Default: default
     + pending_subscription (object) - Details regarding a pending subscription upgrade or downgrade.
     + options (object) - Account-level settings.
-        + allow_anyone_at_domain_verification (boolean) - true if the account can use anyone@ domain verification
+        + allow_anyone_at_domain_verification (boolean) - true if the account can use anyone@ sending domain verification
         + allow_default_bounce_domain (boolean) - true if the account can set a default signing domain
         + allow_default_signing_domains_for_ip_pools (boolean) - true if the account can set a default signing domain on an IP pool
         + allow_subaccount_default_bounce_domain (boolean) - true if the account can set a default bounce domain on a subaccount


### PR DESCRIPTION
### What changed
Added a set of read-only account options which will ultimately be populated by tenant config variables:
 - allow_anyone_at_domain_verification
 - allow_default_bounce_domain
 - allow_default_signing_domains_for_ip_pools
 - allow_subaccount_default_bounce_domain
 - tracking_domain_cname

