### PR TITLE
remove rule that was collapsing multi-line html onto one line

### DIFF
--- a/src/components/api/components/BlockMarkdown/REPL.js
+++ b/src/components/api/components/BlockMarkdown/REPL.js
@@ -55,7 +55,6 @@ const Textarea = styled.textarea`
   box-sizing: content-box;
   padding: .5rem;
   min-height: 100px;
-  white-space: nowrap;
   overflow: auto;
 `
 


### PR DESCRIPTION
Removes a CSS rule that was hiding newlines in template HTML examples