### PR TITLE
changes ingest label to private access

### DIFF
--- a/content/api/events-ingest.apib
+++ b/content/api/events-ingest.apib
@@ -1,7 +1,7 @@
 FORMAT: 1A
 title: Ingest
 description: Send event data to SparkPost for processing
-label: New
+label: Private Access
 
 # Group Ingest
 


### PR DESCRIPTION
Updates the label on the Events Ingest API to indicate it's private access only.