### PR TITLE
ESCSP-3724 updates events docs to call specify from and to are UTC

### DIFF
--- a/content/api/events.apib
+++ b/content/api/events.apib
@@ -116,9 +116,9 @@ If your result set is less than one page of data, then the `links` object will n
 Returns a list of message events that matched the filtered search.
 
 + Parameters
-    + from (string, optional) - Datetime in format of YYYY-MM-DDTHH:MM:ssZ, inclusive.
+    + from (string, optional) - Datetime in format of `YYYY-MM-DDTHH:MM:ssZ`, inclusive. Value should be in UTC.
         + Default: `24 hours ago`
-    + to (string, optional) - Datetime in format of YYYY-MM-DDTHH:MM:ssZ, exclusive.
+    + to (string, optional) - Datetime in format of `YYYY-MM-DDTHH:MM:ssZ`, exclusive. Value should be in UTC.
         + Default: `1 minute ago`
     + cursor (string, optional) - Results cursor for pagination. Used in conjunction with `per_page` parameter. See [Pagination](/api/events/#events-pagination) section for details.
         + Default: `initial`


### PR DESCRIPTION
Per ESCSP-3724 updates events docs to call specify `from` and `to` are UTC.