### PR TITLE
TR-2259 remove banner from transmissions api doc that says scheduledt…

### DIFF
--- a/content/api/transmissions.apib
+++ b/content/api/transmissions.apib
@@ -485,8 +485,6 @@ Content headers are not generated for transmissions providing RFC822 content. Th
 
 ## Scheduled Transmissions [/v1/transmissions]
 
-<Banner status="info">Not available in SparkPost EU.</Banner>
-
 ### Schedule a Transmission [POST /v1/transmissions/]
 
 Create a scheduled transmission to be generated and sent at a future time by specifying `start_time` in the `options` attribute.


### PR DESCRIPTION
…ransmissions 'Not available in SparkPost EU'


<!--

Thank you for the PR!

Please add any appropriate labels to the PR 🏷

If this is your first time contributing, please review the contributing guide:

https://github.com/SparkPost/developers.sparkpost.com/blob/master/CONTRIBUTING.md

-->
