### PR TITLE
resolve-#408 - Resolve sending domains typo

### DIFF
--- a/content/api/sending-domains.apib
+++ b/content/api/sending-domains.apib
@@ -62,7 +62,7 @@ A sending domain can be used as a bounce domain if it is verified via the follow
 * CNAME record
 * MX records (<span class="label label-warning"><strong>Enterprise</strong></span> only).
 
-Once it is verified through one of those two methods, you can use it as a bound domain by including it as a transmission's `return_path` field or SMTP's `MAIL FROM` email address. For additional details on custom bounce domains, please see this [support article](https://www.sparkpost.com/docs/tech-resources/custom-bounce-domain/).
+Once it is verified through one of those two methods, you can use it as a bounce domain by including it as a transmission's `return_path` field or SMTP's `MAIL FROM` email address. For additional details on custom bounce domains, please see this [support article](https://www.sparkpost.com/docs/tech-resources/custom-bounce-domain/).
 
 
 ## Sending Domain Object


### PR DESCRIPTION
Fixes tiny typo in which the word 'bound' was used instead of 'bounce'.