### PR TITLE
Updated timeout values to 60 seconds

### DIFF
--- a/content/api/smtp.apib
+++ b/content/api/smtp.apib
@@ -21,7 +21,7 @@ To use SparkPost as an SMTP relay you need to point your SMTP client or local MT
 | Authentication | `AUTH LOGIN`                                                             | |
 | User           | `SMTP_Injection`                                                         | |
 | Password       | An API key with "Send via SMTP" permission                               | You can create and manage your API Keys from the [app](https://app.sparkpost.com/account/api-keys) ([EU](https://app.eu.sparkpost.com/account/api-keys)). |
-| Per-command Timeout | Minimum 90 seconds | See [RFC-5321](https://tools.ietf.org/html/rfc5321#section-4.5.3.2) for RFC recommended values. |
+| Per-command Timeout | Minimum 60 seconds | See [RFC-5321](https://tools.ietf.org/html/rfc5321#section-4.5.3.2) for RFC recommended values. |
 
 <Banner status="info">Enterprise accounts should contact their Technical Account Manager for SMTP details.</Banner>
 
@@ -31,7 +31,7 @@ To use SparkPost as an SMTP relay you need to point your SMTP client or local MT
 
 SparkPost strongly recommends using TLS with SMTP to protect your message content, recipient information and API keys in transmission. This includes API keys and any details such as recipient email addresses and message content.
 
-SparkPost also strongly recommends reusing existing connections due to the overhead of initiating TLS connections. After injecting 10,000 messages, the client SHOULD disconnect and establish a new connection. Additionally, Sparkpost will automatically disconnect idle connections after 5 minutes.
+SparkPost also strongly recommends reusing existing connections due to the overhead of initiating TLS connections. After injecting 10,000 messages, the client SHOULD disconnect and establish a new connection. Additionally, Sparkpost will automatically disconnect idle connections after 1 minute.
 
 If TLS is not supported by your application, SparkPost recommends using API keys with _only_ the `Send via SMTP` privilege enabled.
 It is also good practice to regularly cycle your API keys to limit exposure of keys sent in the clear.


### PR DESCRIPTION
Idle timeout was incorrectly documented as 300 seconds when in reality our service disconnects after 60 seconds.  See ESCSP-4086.



