### PR TITLE
AC-1741 Replace old algolia indices with updated ones

### DIFF
--- a/src/components/Header/Search/index.js
+++ b/src/components/Header/Search/index.js
@@ -52,8 +52,9 @@ const SectionTitle = styled(({ indexName, ...props }) => (
   <li {...props}>
     <h5>
       {indexName === 'api_reference' && 'API Reference'}
-      {indexName === 'production_site_posts_support_article' && 'Documentation'}
-      {indexName === 'production_site_posts_post' && 'Blog'}
+      {indexName === 'wp_vip_site_production_posts_support_article' &&
+        'Documentation'}
+      {indexName === 'wp_vip_site_production_posts_post' && 'Blog'}
     </h5>
   </li>
 ))`
@@ -123,9 +124,9 @@ const UniversalSearch = () => {
         algolia={{ hitsPerPage: 3 }}
         indexes={[
           'api_reference',
-          'production_site_posts_support_article',
+          'wp_vip_site_production_posts_support_article',
           {
-            indexName: 'production_site_posts_post',
+            indexName: 'wp_vip_site_production_posts_post',
             config: {
               facetFilters:
                 '[["taxonomies_hierarchical.category.lvl0:Developer"]]',


### PR DESCRIPTION
We changed Algolia indices when we migrated the hosting platform of the website. This PR updates the usage of all Algolia indices to their new counterparts.


In order to test:
1. Visit Netlify preview: https://5f8dd5233e49ed0007642b00--developers-sparkpost.netlify.app/
2. Type "getting started" and click on any of the "Documentation" links
3. Expect the link to open www.sparkpost.com instead of sparkpost.kinsta.cloud.
4. Go back and type "continuous integration deployment" and click on any of the "Blog" links.
5. Expect the link to open www.sparkpost.com and not sparkpost.kinsta.cloud.
