### PR TITLE
SA-1746 Added listing and aggregate subject-campaigns endpoints

### DIFF
--- a/content/api/metrics.apib
+++ b/content/api/metrics.apib
@@ -295,6 +295,11 @@ The Metrics API is designed for discoverability of child links. Calling the API 
                   "href": "/api/v1/metrics/sending-ips",
                   "rel": "sending-ips",
                   "method": "GET"
+                },
+                {
+                  "href": "/api/v1/metrics/subject-campaigns",
+                  "rel": "subject-campaigns",
+                  "method": "GET"
                 }
             ]
         }
@@ -1091,6 +1096,105 @@ Provides aggregate metrics grouped by template over the time window specified.
                 }
             ]
         }
+
+        
+### Metrics by Subject Campaign [GET /v1/metrics/deliverability/subject-campaign{?from,to,delimiter,domains,campaigns,templates,sending_ips,ip_pools,sending_domains,subaccounts,precision,metrics,timezone,limit,order_by}]
+
+Note: Requires Deliverability product
+
+Provides aggregate metrics grouped by deliverability subject campaign over the time window specified.
+
++ Parameters
+    + from (required, datetime, `2018-07-11T08:00`) ... Datetime in format of `YYYY-MM-DDTHH:MM`.
+    + to = `now` (optional, datetime) ... Datetime in format of `YYYY-MM-DDTHH:MM`.
+    + delimiter = `,` (optional, string) ... Specifies the delimiter for query parameter lists.
+    + query_filters = (optional, string) ... An advanced query structure. See [Advanced Filters](#header-advanced-filters).
+    + domains (optional, list) ... Delimited list of recipient domains to include.
+    + campaigns (optional, list) ... Delimited list of campaigns to include.
+    + templates (optional, list) ... Delimited list of template IDs to include.
+    + sending_ips (optional, list) ... Delimited list of sending IPs to include.
+    + ip_pools (optional, list) ... Delimited list of IP pools to include.
+    + sending_domains (optional, list) ... Delimited list of sending domains to include.
+    + subaccounts (optional, list) ... Delimited list of subaccount IDs to include.
+    + precision = `1min` (optional, enum) ...
+
+        Precision of the time window (`from`, `to`) bounds. All values valid up to a 24 hour window, except for `hour` which is also valid up a 31 day window.
+        See: [Precision Parameter](#header-precision-parameter).
+
+        + Values
+            + `1min`
+            + `5min`
+            + `15min`
+            + `hour`
+
+    + metrics (required, list) ... Delimited list of metrics for filtering.
+
+        + Values
+            + `count_injected`
+            + `count_bounce`
+            + `count_rejected`
+            + `count_delivered`
+            + `count_delivered_first`
+            + `count_delivered_subsequent`
+            + `total_delivery_time_first`
+            + `total_delivery_time_subsequent`
+            + `total_msg_volume`
+            + `count_policy_rejection`
+            + `count_generation_rejection`
+            + `count_generation_failed`
+            + `count_inband_bounce`
+            + `count_outofband_bounce`
+            + `count_soft_bounce`
+            + `count_hard_bounce`
+            + `count_block_bounce`
+            + `count_admin_bounce`
+            + `count_undetermined_bounce`
+            + `count_delayed`
+            + `count_delayed_first`
+            + `count_rendered`
+            + `count_unique_rendered`
+            + `count_unique_confirmed_opened`
+            + `count_clicked`
+            + `count_unique_clicked`
+            + `count_targeted`
+            + `count_sent`
+            + `count_accepted`
+            + `count_spam_complaint`
+
+    + timezone =`UTC` (optional, string) ... Standard timezone identification string.
+    + limit=1000 (optional, int, `5`) ... Maximum number of results to return between 1 and 10000, inclusive.
+    + order_by (optional, string) - Metric by which to order results.
+    + Sample: count_injected
+
++ Request
+
+    + Headers
+
+            Authorization: 14ac5499cfdd2bb2859e4476d2e5b1d2bad079bf
+            Accept: application/json
+
++ Response 200 (application/json)
+
+        {
+            "results": [
+                {
+                    "subject_campaign": "campaign-0",
+                    "count_targeted": 34432,
+                    "count_injected": 32323,
+                    "count_rejected": 2343,
+                    "count_sent": 34344
+                },
+                {
+                    "subject_campaign": "campaign-1",
+                    "count_targeted": 34432,
+                    "count_injected": 32323,
+                    "count_rejected": 2343,
+                    "count_sent": 34344
+                }
+            ]
+        }
+
+
 
 ### Metrics by Watched Domain [GET /v1/metrics/deliverability/watched-domain{?from,to,delimiter,domains,campaigns,templates,sending_ips,ip_pools,sending_domains,subaccounts,precision,metrics,timezone,limit,order_by}]
 
@@ -1932,6 +2036,39 @@ Returns a list of domains that the Metrics API contains data on.
                     "msn.com",
                     "aol.com",
                     "hotmail.com"
+                ]
+            }
+        }
+        
+### Subject Campaigns [GET /v1/metrics/subject-campaigns{?from,to,timezone,limit,match}]
+
+Returns a list of deliverability subject campaigns that the Metrics API contains data on.
+
++ Parameters
+    + match (optional, string) ... Only return results containing this string.
+    + limit (optional, int, `5`) ... Maximum number of results to return.
+    + from (optional, datetime, `2017-12-01T08:00`) ... Datetime in format of `YYYY-MM-DDTHH:MM`.
+    + to = `now` (optional, datetime, `2017-12-01T09:00`) ... Datetime in format of `YYYY-MM-DDTHH:MM`.
+    + timezone =`UTC` (optional, string) ... Standard timezone identification string.
+
++ Request
+
+    + Headers
+
+            Authorization: 14ac5499cfdd2bb2859e4476d2e5b1d2bad079bf
+            Accept: application/json
+
++ Response 200
+
+        {
+            "results": {
+                "subject-campaigns": [
+                    "Hi there!",
+                    "Hi [REDACTED]",
+                    "exciting offers.",
+                    "[REDACTED] there!",
+                    "[REDACTED] offers.",
+                    "exciting [REDACTED]"
                 ]
             }
         }


### PR DESCRIPTION
- Document the new API endpoint
- Add new route GET/api/v1/metrics/deliverability/subject-campaign that returns sending and deliverability data grouped by it-campaign
- Add new route GET/api/v1/metrics/subject-campaigns that lists subject campaigns. Query parameters should mirror other list endpoints.
- verify that Access Control works correctly (only for accounts with the d12y product)