### PR TITLE
Sa 95

### DIFF
--- a/content/api/metrics.apib
+++ b/content/api/metrics.apib
@@ -129,7 +129,7 @@ Example:
 ````
 **Compare Group**
 
-The compare objects have a single logical comparison operator (`OR` or `AND`) that will be used to compare all of the filter conditions in the group
+The compare objects have a single logical comparison operator (`OR` or `AND`) that will be used to compare all of the filter conditions in the group.
 
 Example:
 ````json
@@ -245,6 +245,7 @@ Compressed (whitespace and line end characters removed) and URL encoded:
 ```
 ?query_filters=%7B%22groupings%22%3A%5B%7B%22AND%22%3A%7B%22domains%22%3A%7B%22eq%22%3A%5B%22gmail.com%22%2C%22yahoo.com%22%2C%22hotmail.com%22%5D%2C%22like%22%3A%5B%22mail%22%5D%7D%2C%22sending_domains%22%3A%7B%22notEq%22%3A%5B%22sparkpost.com%22%5D%7D%7D%7D%2C%7B%22OR%22%3A%7B%22templates%22%3A%7B%22eq%22%3A%5B%22default%22%5D%7D%2C%22campaigns%22%3A%7B%22like%22%3A%5B%22333%22%2C%22344%22%2C%22355%22%5D%7D%7D%7D%2C%7B%22OR%22%3A%7B%22campaigns%22%3A%7B%22notLike%22%3A%5B%22Friday%22%5D%2C%22notEq%22%3A%5B%22stuff%22%2C%22things%22%5D%7D%7D%7D%5D%7D
 ```
+Multiple compare groups are evaluated such that the relationship between them is an AND operation.
 
 ### Advanced Query JSON Schema [GET /v1/metrics/deliverability/query-filters-schema]
 

--- a/content/api/metrics.apib
+++ b/content/api/metrics.apib
@@ -69,20 +69,18 @@ Note: The metrics `count_inbox_panel`,`count_spam_panel`,
 When the `precision` parameter is specified for aggregate metric requests, the bounds of the time window (`from`, `to`) are rounded to the nearest time matching the precision.
 For example, requesting data between `4:22` to `6:37` would return results within the following time windows:
 
-| Precision | Rounded time window   |
-|-----------|-----------------------|
-| `1min`    | `4:22:00` - `6:36:59` |
-| `5min`    | `4:20:00` - `6:39:59` |
-| `15min`   | `4:15:00` - `6:44:59` |
-| `hour`    | `4:00:00` - `6:59:59` |
-
-All precisions are valid up to a 24 hour time window. `15min` precision is valid up to a 48 hour time window. Hour precision is valid up to a 31 day time window.
-
+| Precision | Rounded time window     | Max time window |
+|-----------|-------------------------|-----------------|
+| `1min`    | `04:22:00` - `06:36:59` | `24 hours`      |
+| `5min`    | `04:20:00` - `06:39:59` | `24 hours`      |
+| `15min`   | `04:15:00` - `06:44:59` | `48 hours`      |
+| `hour`    | `04:00:00` - `06:59:59` | `31 days`       |
+| `day`     | `00:00:00` - `23:59:59` | `No max`        |
 
 **Time-series Metrics**
 
 When the `precision` parameter is specified for the [time-series request](#metrics-get-time-series-metrics), it reflects the period of time the data is grouped by.
-
+The same max time window ranges apply for time-series requests as do aggregate requests.
 
 ## Filters
 

--- a/content/api/metrics.apib
+++ b/content/api/metrics.apib
@@ -2108,6 +2108,38 @@ Returns a list of campaigns that the Metrics API contains data on.
             }
         }
 
+### Templates [GET /v1/metrics/templates{?from,to,timezone,limit,match}]
+
+Returns a list of templates that the Metrics API contains data on.
+
++ Parameters
+    + match (optional, string) ... Only return results containing this string.
+    + limit (optional, int, `5`) ... Maximum number of results to return.
+    + from (optional, datetime, `2017-12-01T08:00`) ... Datetime in format of `YYYY-MM-DDTHH:MM`.
+    + to = `now` (optional, datetime, `2017-12-01T09:00`) ... Datetime in format of `YYYY-MM-DDTHH:MM`.
+    + timezone =`UTC` (optional, string) ... Standard timezone identification string.
+
++ Request
+
+    + Headers
+
+            Authorization: 14ac5499cfdd2bb2859e4476d2e5b1d2bad079bf
+            Accept: application/json
+
++ Response 200
+
+        {
+            "results": {
+                "templates": [
+                    "labor-day-sale",
+                    "inline",
+                    "welcome-user",
+                    "winter-event-001",
+                    "promotion-x"
+                ]
+            }
+        }
+
 ### Domains [GET /v1/metrics/domains{?from,to,timezone,limit,match}]
 
 Returns a list of domains that the Metrics API contains data on.

--- a/content/api/metrics.apib
+++ b/content/api/metrics.apib
@@ -64,8 +64,6 @@ Note: The metrics `count_inbox_panel`,`count_spam_panel`,
 
 ## Precision Parameter
 
-**Aggregate Metrics**
-
 When the `precision` parameter is specified for aggregate metric requests, the bounds of the time window (`from`, `to`) are rounded to the nearest time matching the precision.
 For example, requesting data between `4:22` to `6:37` would return results within the following time windows:
 
@@ -356,9 +354,9 @@ The Metrics API is designed for discoverability of child links. Calling the API 
         }
 
 
-## Deliverability [/v1/metrics/deliverability]
+## Aggregations [/v1/metrics/deliverability]
 
-The deliverability endpoints allow you to get high-level summaries of your data grouped by specific quantifiers such as sending domain or template. You can also get specific types of data, such as rejection reason, to better understand your sending.
+The aggregations endpoints allow you to get high-level summaries of your data grouped by specific quantifiers such as sending domain or template. You can also get specific types of data, such as rejection reason, to better understand your sending.
 
 Use the `subaccount` field to get metrics about individual subaccounts or set it to 0 to get only the primary account's data.
 
@@ -374,7 +372,7 @@ aggregate data, which can be used as "group by" qualifiers.
     + query_filters = (optional, string) ... An advanced query structure. See [Advanced Filters](#header-advanced-filters).
     + domains (optional, list) ... Delimited list of recipient domains to include.
     + campaigns (optional, list) ... Delimited list of campaigns to include.
-    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Delimited list of subject campaigns to include. Supports deliverability metrics only.
+    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Delimited list of subject campaigns to include. Supports deliverability add-on metrics only.
     + templates (optional, list) ... Delimited list of template IDs to include.
     + sending_ips (optional, list) ... Delimited list of sending IPs to include.
     + ip_pools (optional, list) ... Delimited list of IP pools to include.
@@ -475,7 +473,7 @@ Provides aggregate metrics grouped by domain over the time window specified.
     + query_filters = (optional, string) ... An advanced query structure. See [Advanced Filters](#header-advanced-filters).
     + domains (optional, list) ... Delimited list of recipient domains to include.
     + campaigns (optional, list) ... Delimited list of campaigns to include.
-    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Delimited list of subject campaigns to include. Supports deliverability metrics only.
+    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Delimited list of subject campaigns to include. Supports deliverability add-on metrics only.
     + templates (optional, list) ... Delimited list of template IDs to include.
     + sending_ips (optional, list) ... Delimited list of sending IPs to include.
     + ip_pools (optional, list) ... Delimited list of IP pools to include.
@@ -580,7 +578,7 @@ Provides aggregate metrics grouped by sending IP over the time window specified.
     + query_filters = (optional, string) ... An advanced query structure. See [Advanced Filters](#header-advanced-filters).
     + domains (optional, list) ... Delimited list of recipient domains to include.
     + campaigns (optional, list) ... Delimited list of campaigns to include.
-    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Delimited list of subject campaigns to include. Supports deliverability metrics only.
+    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Delimited list of subject campaigns to include. Supports deliverability add-on metrics only.
     + templates (optional, list) ... Delimited list of template IDs to include.
     + sending_ips (optional, list) ... Delimited list of sending IPs to include.
     + ip_pools (optional, list) ... Delimited list of IP pools to include.
@@ -685,7 +683,7 @@ Provides aggregate metrics grouped by IP pool over the time window specified.
     + query_filters = (optional, string) ... An advanced query structure. See [Advanced Filters](#header-advanced-filters).
     + domains (optional, list) ... Delimited list of recipient domains to include.
     + campaigns (optional, list) ... Delimited list of campaigns to include.
-    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Delimited list of subject campaigns to include. Supports deliverability metrics only.
+    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Delimited list of subject campaigns to include. Supports deliverability add-on metrics only.
     + templates (optional, list) ... Delimited list of template IDs to include.
     + sending_ips (optional, list) ... Delimited list of sending IPs to include.
     + ip_pools (optional, list) ... Delimited list of IP pools to include.
@@ -788,7 +786,7 @@ Provides aggregate metrics grouped by sending domain over the time window specif
     + query_filters = (optional, string) ... An advanced query structure. See [Advanced Filters](#header-advanced-filters).
     + domains (optional, list) ... Delimited list of recipient domains to include.
     + campaigns (optional, list) ... Delimited list of campaigns to include.
-    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Delimited list of subject campaigns to include. Supports deliverability metrics only.
+    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Delimited list of subject campaigns to include. Supports deliverability add-on metrics only.
     + templates (optional, list) ... Delimited list of template IDs to include.
     + sending_ips (optional, list) ... Delimited list of sending IPs to include.
     + ip_pools (optional, list) ... Delimited list of IP pools to include.
@@ -904,7 +902,7 @@ Provides aggregate metrics grouped by subaccount over the time window specified.
     + query_filters = (optional, string) ... An advanced query structure. See [Advanced Filters](#header-advanced-filters).
     + domains (optional, list) ... Delimited list of recipient domains to include.
     + campaigns (optional, list) ... Delimited list of campaigns to include.
-    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Delimited list of subject campaigns to include. Supports deliverability metrics only.
+    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Delimited list of subject campaigns to include. Supports deliverability add-on metrics only.
     + templates (optional, list) ... Delimited list of template IDs to include.
     + sending_ips (optional, list) ... Delimited list of sending IPs to include.
     + ip_pools (optional, list) ... Delimited list of IP pools to include.
@@ -1020,7 +1018,7 @@ Provides aggregate metrics grouped by campaign over the time window specified.
     + query_filters = (optional, string) ... An advanced query structure. See [Advanced Filters](#header-advanced-filters).
     + domains (optional, list) ... Delimited list of recipient domains to include.
     + campaigns (optional, list) ... Delimited list of campaigns to include.
-    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Delimited list of subject campaigns to include. Supports deliverability metrics only.
+    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Delimited list of subject campaigns to include. Supports deliverability add-on metrics only.
     + templates (optional, list) ... Delimited list of template IDs to include.
     + sending_ips (optional, list) ... Delimited list of sending IPs to include.
     + ip_pools (optional, list) ... Delimited list of IP pools to include.
@@ -1124,7 +1122,7 @@ Provides aggregate metrics grouped by template over the time window specified.
     + query_filters = (optional, string) ... An advanced query structure. See [Advanced Filters](#header-advanced-filters).
     + domains (optional, list) ... Delimited list of recipient domains to include.
     + campaigns (optional, list) ... Delimited list of campaigns to include.
-    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Delimited list of subject campaigns to include. Supports deliverability metrics only.
+    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Delimited list of subject campaigns to include. Supports deliverability add-on metrics only.
     + templates (optional, list) ... Delimited list of template IDs to include.
     + sending_ips (optional, list) ... Delimited list of sending IPs to include.
     + ip_pools (optional, list) ... Delimited list of IP pools to include.
@@ -1222,7 +1220,7 @@ Provides aggregate metrics grouped by template over the time window specified.
 Note: Only available to SparkPost <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> customers
 
 
-Provides aggregate metrics grouped by deliverability subject campaign over the time window specified.
+Provides aggregate metrics grouped by deliverability add-on subject campaign over the time window specified.
 
 + Parameters
     + from (required, datetime, `2018-07-11T08:00`) ... Datetime in format of `YYYY-MM-DDTHH:MM`.
@@ -1231,7 +1229,7 @@ Provides aggregate metrics grouped by deliverability subject campaign over the t
     + query_filters = (optional, string) ... An advanced query structure. See [Advanced Filters](#header-advanced-filters).
     + domains (optional, list) ... Delimited list of recipient domains to include.
     + campaigns (optional, list) ... Delimited list of campaigns to include.
-    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Delimited list of subject campaigns to include. Supports deliverability metrics only.
+    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Delimited list of subject campaigns to include. Supports deliverability add-on metrics only.
     + templates (optional, list) ... Delimited list of template IDs to include.
     + sending_ips (optional, list) ... Delimited list of sending IPs to include.
     + ip_pools (optional, list) ... Delimited list of IP pools to include.
@@ -1250,7 +1248,7 @@ Provides aggregate metrics grouped by deliverability subject campaign over the t
             + `hour`
             + `day`
 
-    + metrics (required, list) ... Delimited list of metrics for filtering. Supports deliverability metrics only.
+    + metrics (required, list) ... Delimited list of metrics for filtering. Supports deliverability add-on metrics only.
 
         + Values
             + `count_inbox_panel`
@@ -1312,7 +1310,7 @@ in the world.
     + query_filters = (optional, string) ... An advanced query structure. See [Advanced Filters](#header-advanced-filters).
     + domains (optional, list) ... Delimited list of recipient domains to include.
     + campaigns (optional, list) ... Delimited list of campaigns to include.
-    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Delimited list of subject campaigns to include. Supports deliverability metrics only.
+    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Delimited list of subject campaigns to include. Supports deliverability add-on metrics only.
     + templates (optional, list) ... Delimited list of template IDs to include.
     + sending_ips (optional, list) ... Delimited list of sending IPs to include.
     + ip_pools (optional, list) ... Delimited list of IP pools to include.
@@ -1407,7 +1405,7 @@ in the world.
 
 ### Time-Series Metrics [GET /v1/metrics/deliverability/time-series{?from,to,delimiter,domains,campaigns,templates,sending_ips,ip_pools,sending_domains,subaccounts,precision,metrics,timezone}]
 
-Provides deliverability metrics ordered by a precision of time.
+Provides aggregate metrics ordered by a precision of time.
 
 + Parameters
     + from (required, datetime, `2020-10-04T00:00`) ... Datetime in format of `YYYY-MM-DDTHH:MM`.
@@ -1416,7 +1414,7 @@ Provides deliverability metrics ordered by a precision of time.
     + query_filters = (optional, string) ... An advanced query structure. See [Advanced Filters](#header-advanced-filters).
     + domains (optional, list `gmail.com,yahoo.com,hotmail.com`) ... Delimited list of domains for filtering.
     + campaigns (optional, list, `summerSale,promotionX`) ... Delimited list of campaigns for filtering.
-    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Delimited list of subject campaigns to include. Supports deliverability metrics only.    
+    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Delimited list of subject campaigns to include. Supports deliverability add-on metrics only.    
     + templates (optional, list) ... Delimited list of template IDs to include.
     + sending_ips (optional, list) ... Delimited list of sending IPs to include.
     + ip_pools (optional, list, `ip-pool-1,ip-pool-2,ip-pool-3`) ... Delimited list of IP pools to include.
@@ -1565,7 +1563,7 @@ Provides deliverability metrics ordered by a precision of time.
 
 ### Bounce Reason Metrics [GET /v1/metrics/deliverability/bounce-reason{?from,to,delimiter,domains,campaigns,templates,sending_ips,ip_pools,sending_domains,subaccounts,metrics,timezone,limit}]
 
-Provides deliverability metrics, specific to bounce events, grouped by the bounce reasons.
+Provides aggregate metrics, specific to bounce events, grouped by the bounce reasons.
 
 + Parameters
     + from (required, datetime, `2018-07-11T08:00`) ... Datetime in format of `YYYY-MM-DDTHH:MM`.
@@ -1629,7 +1627,7 @@ Provides deliverability metrics, specific to bounce events, grouped by the bounc
 
 ### Bounce Reason Metrics By Domain [GET /v1/metrics/deliverability/bounce-reason/domain{?from,to,delimiter,domains,campaigns,templates,sending_ips,ip_pools,sending_domains,subaccounts,metrics,timezone,limit}]
 
-Provides deliverability metrics, specific to bounce events, grouped by the domain and bounce reasons.
+Provides aggregate metrics, specific to bounce events, grouped by the domain and bounce reasons.
 
 + Parameters
     + from (required, datetime, `2018-07-11T08:00`) ... Datetime in format of `YYYY-MM-DDTHH:MM`.
@@ -1695,7 +1693,7 @@ Provides deliverability metrics, specific to bounce events, grouped by the domai
 
 ### Bounce Classification Metrics [GET /v1/metrics/deliverability/bounce-classification{?from,to,delimiter,domains,campaigns,templates,sending_ips,ip_pools,sending_domains,subaccounts,metrics,timezone,limit}]
 
-Provides deliverability metrics, specific to bounce events, grouped by the bounce classification. (See [Bounce Classification Codes.](https://www.sparkpost.com/docs/deliverability/bounce-classification-codes/))
+Provides aggregate metrics, specific to bounce events, grouped by the bounce classification. (See [Bounce Classification Codes.](https://www.sparkpost.com/docs/deliverability/bounce-classification-codes/))
 
 + Parameters
     + from (required, datetime, `2018-07-11T08:00`) ... Datetime in format of `YYYY-MM-DDTHH:MM`.
@@ -1755,7 +1753,7 @@ Provides deliverability metrics, specific to bounce events, grouped by the bounc
 
 ### Rejection Reason Metrics [GET /v1/metrics/deliverability/rejection-reason{?from,to,delimiter,domains,campaigns,templates,sending_ips,ip_pools,sending_domains,subaccounts,timezone,limit}]
 
-Provides deliverability metrics, specific to rejection events, grouped by the rejection reasons.
+Provides aggregate metrics, specific to rejection events, grouped by the rejection reasons.
 
 + Parameters
     + from (required, datetime, `2018-07-11T08:00`) ... Datetime in format of `YYYY-MM-DDTHH:MM`.
@@ -1794,7 +1792,7 @@ Provides deliverability metrics, specific to rejection events, grouped by the re
 
 ### Rejection Reason Metrics By Domain [GET /v1/metrics/deliverability/rejection-reason/domain{?from,to,delimiter,domains,campaigns,templates,sending_ips,ip_pools,sending_domains,subaccounts,timezone,limit}]
 
-Provides deliverability metrics, specific to rejection events, grouped by the domain and rejection reasons.
+Provides aggregate metrics, specific to rejection events, grouped by the domain and rejection reasons.
 
 + Parameters
     + from (required, datetime, `2018-07-11T08:00`) ... Datetime in format of `YYYY-MM-DDTHH:MM`.
@@ -1835,7 +1833,7 @@ Provides deliverability metrics, specific to rejection events, grouped by the do
 
 ### Delay Reason Metrics [GET /v1/metrics/deliverability/delay-reason{?from,to,delimiter,domains,campaigns,templates,sending_ips,ip_pools,sending_domains,subaccounts,timezone,limit}]
 
-Provides deliverability metrics, specific to delay events, grouped by the delay reasons.
+Provides aggregate metrics, specific to delay events, grouped by the delay reasons.
 
 + Parameters
     + from (required, datetime, `2018-07-11T08:00`) ... Datetime in format of `YYYY-MM-DDTHH:MM`.
@@ -1879,7 +1877,7 @@ Provides deliverability metrics, specific to delay events, grouped by the delay 
 
 ### Delay Reason Metrics By Domain [GET /v1/metrics/deliverability/delay-reason/domain{?from,to,delimiter,domains,campaigns,templates,sending_ips,ip_pools,sending_domains,subaccounts,timezone,limit}]
 
-Provides deliverability metrics, specific to delay events, grouped by the domain and delay reasons.
+Provides aggregagte metrics, specific to delay events, grouped by the domain and delay reasons.
 
 + Parameters
     + from (required, datetime, `2018-07-11T08:00`) ... Datetime in format of `YYYY-MM-DDTHH:MM`.
@@ -2193,7 +2191,7 @@ Returns a list of domains that the Metrics API contains data on.
         
 ### Subject Campaigns [GET /v1/metrics/subject-campaigns{?from,to,timezone,limit,match}]
 
-Returns a list of deliverability subject campaigns that the Metrics API contains data on.
+Returns a list of deliverability add-on subject campaigns that the Metrics API contains data on.
 
 + Parameters
     + match (optional, string) ... Only return results containing this string.

--- a/content/api/metrics.apib
+++ b/content/api/metrics.apib
@@ -109,7 +109,7 @@ e.g. in `?domains=mailing.com&query_filters={}`, the domains query parameter wil
 Other query parameters like `from`, `to`, `metrics`, `limit`, etc., will be processed as expected.
 
 #### Groupings Structure 
-The JSON object consists of a top level "groupings" key that has an array of compare objects.
+The JSON object consists of a root level "groupings" array containing compare objects. Multiple compare groups are evaluated such that the relationship between them is an AND operation.
 
 Example:
 ````json
@@ -125,7 +125,6 @@ Example:
 }
 
 ````
-Multiple compare groups are evaluated such that the relationship between them is an AND operation.
 
 **Compare Group**
 

--- a/content/api/metrics.apib
+++ b/content/api/metrics.apib
@@ -102,14 +102,14 @@ The Metrics API uses [JSON Schema](https://json-schema.org/) to define and valid
 Advanced Filter requests that do not adhere to the schema will result in a `400` error response. 
 Specific schema violations will be attached to the `validationErrors` property of the error response.
 The exact schema can be retrieved through the `/deliverability/query-filters-schema` endpoint. 
-See [Advanced Query JSON Schema](#header-advanced-query-json-schema).
+See [Advanced Query JSON Schema](#metrics-get-advanced-query-json-schema).
 
 Please note, advanced filters cannot be used in conjunction with simple filters. Simple filters will be ignored if the `query_filters` parameter is used. 
 e.g. in `?domains=mailing.com&query_filters={}`, the domains query parameter will be ignored. 
 Other query parameters like `from`, `to`, `metrics`, `limit`, etc., will be processed as expected.
 
 #### Groupings Structure 
-The JSON object consists of a top level "groupings" key that has an array of compare objects
+The JSON object consists of a top level "groupings" key that has an array of compare objects.
 
 Example:
 ````json
@@ -125,6 +125,8 @@ Example:
 }
 
 ````
+Multiple compare groups are evaluated such that the relationship between them is an AND operation.
+
 **Compare Group**
 
 The compare objects have a single logical comparison operator (`OR` or `AND`) that will be used to compare all of the filter conditions in the group.
@@ -243,7 +245,6 @@ Compressed (whitespace and line end characters removed) and URL encoded:
 ```
 ?query_filters=%7B%22groupings%22%3A%5B%7B%22AND%22%3A%7B%22domains%22%3A%7B%22eq%22%3A%5B%22gmail.com%22%2C%22yahoo.com%22%2C%22hotmail.com%22%5D%2C%22like%22%3A%5B%22mail%22%5D%7D%2C%22sending_domains%22%3A%7B%22notEq%22%3A%5B%22sparkpost.com%22%5D%7D%7D%7D%2C%7B%22OR%22%3A%7B%22templates%22%3A%7B%22eq%22%3A%5B%22default%22%5D%7D%2C%22campaigns%22%3A%7B%22like%22%3A%5B%22333%22%2C%22344%22%2C%22355%22%5D%7D%7D%7D%2C%7B%22OR%22%3A%7B%22campaigns%22%3A%7B%22notLike%22%3A%5B%22Friday%22%5D%2C%22notEq%22%3A%5B%22stuff%22%2C%22things%22%5D%7D%7D%7D%5D%7D
 ```
-Multiple compare groups are evaluated such that the relationship between them is an AND operation.
 
 ### Advanced Query JSON Schema [GET /v1/metrics/deliverability/query-filters-schema]
 

--- a/content/api/metrics.apib
+++ b/content/api/metrics.apib
@@ -248,6 +248,48 @@ Compressed (whitespace and line end characters removed) and URL encoded:
 ?query_filters=%7B%22groupings%22%3A%5B%7B%22AND%22%3A%7B%22domains%22%3A%7B%22eq%22%3A%5B%22gmail.com%22%2C%22yahoo.com%22%2C%22hotmail.com%22%5D%2C%22like%22%3A%5B%22mail%22%5D%7D%2C%22sending_domains%22%3A%7B%22notEq%22%3A%5B%22sparkpost.com%22%5D%7D%7D%7D%2C%7B%22OR%22%3A%7B%22templates%22%3A%7B%22eq%22%3A%5B%22default%22%5D%7D%2C%22campaigns%22%3A%7B%22like%22%3A%5B%22333%22%2C%22344%22%2C%22355%22%5D%7D%7D%7D%2C%7B%22OR%22%3A%7B%22campaigns%22%3A%7B%22notLike%22%3A%5B%22Friday%22%5D%2C%22notEq%22%3A%5B%22stuff%22%2C%22things%22%5D%7D%7D%7D%5D%7D
 ```
 
+### Advanced Query JSON Schema [GET /v1/metrics/deliverability/query-filters-schema]
+
+Retrieves the JSON schema for validating the `query_filters` JSON value.
+
++ Request
+
+    + Headers
+
+            Authorization: 14ac5499cfdd2bb2859e4476d2e5b1d2bad079bf
+            Accept: application/json
+
++ Response 200
+
+        {
+            "results": {
+                "$schema": "http://json-schema.org/draft-07/schema",
+                "$id": "root",
+                "type": "object",
+                "title": "The root schema",
+                "description": "The root schema comprises the entire JSON document.",
+                "default": {},
+                "required": [
+                    "groupings"
+                ],
+                "properties": {
+                    ...
+                },
+                "additionalProperties": false,
+                "$defs": {
+                    "groupings": {
+                        ...
+                    },
+                    "filters": {
+                        ...
+                    },
+                    "logicalOperators": {
+                        ...
+                    }
+                }
+            }
+        }
+
 ### Discoverability Links [GET /v1/metrics/]
 
 The Metrics API is designed for discoverability of child links. Calling the API root displays a list of URIs that exists within the Metrics API.
@@ -320,10 +362,6 @@ The Metrics API is designed for discoverability of child links. Calling the API 
 The deliverability endpoints allow you to get high-level summaries of your data grouped by specific quantifiers such as sending domain or template. You can also get specific types of data, such as rejection reason, to better understand your sending.
 
 Use the `subaccount` field to get metrics about individual subaccounts or set it to 0 to get only the primary account's data.
-
-### Advanced Query JSON Schema [/v1/metrics/deliverability/query-filters-schema]
-
-Retrieves the JSON schema for validating the `query_filters` JSON value.
 
 ### Metrics Summary [GET /v1/metrics/deliverability{?from,to,delimiter,domains,campaigns,templates,sending_ips,ip_pools,sending_domains,subaccounts,precision,metrics,timezone}]
 

--- a/content/api/metrics.apib
+++ b/content/api/metrics.apib
@@ -49,16 +49,16 @@ Definitions for terms found in Metrics API
 | `total_delivery_time_first`      | Total time taken to deliver messages on first attempt (milliseconds)                                |
 | `total_delivery_time_subsequent` | Total time taken to delivery messages on subsequent attempts (milliseconds)                         |
 | `count_unsubscribe`              | Total number of unsubscribes as a result of clicked links and the ISP list unsubscribe feature      |
-| `count_inbox_panel`              | <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability</span></a> Panel messages delivered to the inbox.                                                              |
-| `count_spam_panel`               | <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability</span></a> Panel messages delivered to the spam folder.                                                        |
-| `count_inbox_seed`               | <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability</span></a> Seed messages delivered to the inbox.                                                               |
-| `count_spam_seed`                | <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability</span></a> Seed messages delivered to the spam folder.                                                         |
-| `count_moved_to_inbox`           | <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability</span></a> Panel messages delivered to the spam folder then moved to the inbox.                                |
-| `count_moved_to_spam`            | <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability</span></a> Panel messages delivered to the inbox then moved to the spam folder.                                |
+| `count_inbox_panel`              | <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Panel messages delivered to the inbox.                                                              |
+| `count_spam_panel`               | <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Panel messages delivered to the spam folder.                                                        |
+| `count_inbox_seed`               | <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Seed messages delivered to the inbox.                                                               |
+| `count_spam_seed`                | <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Seed messages delivered to the spam folder.                                                         |
+| `count_moved_to_inbox`           | <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Panel messages delivered to the spam folder then moved to the inbox.                                |
+| `count_moved_to_spam`            | <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Panel messages delivered to the inbox then moved to the spam folder.                                |
 
 Note: The metrics `count_inbox_panel`,`count_spam_panel`,
 `count_inbox_seed`,`count_spam_seed`,`count_moved_to_inbox`,
- and `count_moved_to_spam` are only available to the SparkPost <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability</span></a> customers. 
+ and `count_moved_to_spam` are only available to the SparkPost <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> customers. 
 
 <Banner status="info">For a given request, average first attempt delivery latency can be calculated as <code>total_delivery_time_first / count_delivered</code>. A similar calculation holds for <code>total_delivery_time_subsequent</code>.</Banner>
 
@@ -80,7 +80,7 @@ For example, requesting data between `4:22` to `6:37` would return results withi
 **Time-series Metrics**
 
 When the `precision` parameter is specified for the [time-series request](#metrics-get-time-series-metrics), it reflects the period of time the data is grouped by.
-The same max time window ranges apply for time-series requests as do aggregate requests.
+The same max time window ranges apply for time-series requests as do aggregate requests. Precisions `12hr`, `week`, and `month` may also be used for time-series requests.
 
 ## Filters
 
@@ -374,7 +374,7 @@ aggregate data, which can be used as "group by" qualifiers.
     + query_filters = (optional, string) ... An advanced query structure. See [Advanced Filters](#header-advanced-filters).
     + domains (optional, list) ... Delimited list of recipient domains to include.
     + campaigns (optional, list) ... Delimited list of campaigns to include.
-    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability</span></a> Delimited list of subject campaigns to include. Supports deliverability metrics only.
+    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Delimited list of subject campaigns to include. Supports deliverability metrics only.
     + templates (optional, list) ... Delimited list of template IDs to include.
     + sending_ips (optional, list) ... Delimited list of sending IPs to include.
     + ip_pools (optional, list) ... Delimited list of IP pools to include.
@@ -475,7 +475,7 @@ Provides aggregate metrics grouped by domain over the time window specified.
     + query_filters = (optional, string) ... An advanced query structure. See [Advanced Filters](#header-advanced-filters).
     + domains (optional, list) ... Delimited list of recipient domains to include.
     + campaigns (optional, list) ... Delimited list of campaigns to include.
-    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability</span></a> Delimited list of subject campaigns to include. Supports deliverability metrics only.
+    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Delimited list of subject campaigns to include. Supports deliverability metrics only.
     + templates (optional, list) ... Delimited list of template IDs to include.
     + sending_ips (optional, list) ... Delimited list of sending IPs to include.
     + ip_pools (optional, list) ... Delimited list of IP pools to include.
@@ -580,7 +580,7 @@ Provides aggregate metrics grouped by sending IP over the time window specified.
     + query_filters = (optional, string) ... An advanced query structure. See [Advanced Filters](#header-advanced-filters).
     + domains (optional, list) ... Delimited list of recipient domains to include.
     + campaigns (optional, list) ... Delimited list of campaigns to include.
-    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability</span></a> Delimited list of subject campaigns to include. Supports deliverability metrics only.
+    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Delimited list of subject campaigns to include. Supports deliverability metrics only.
     + templates (optional, list) ... Delimited list of template IDs to include.
     + sending_ips (optional, list) ... Delimited list of sending IPs to include.
     + ip_pools (optional, list) ... Delimited list of IP pools to include.
@@ -685,7 +685,7 @@ Provides aggregate metrics grouped by IP pool over the time window specified.
     + query_filters = (optional, string) ... An advanced query structure. See [Advanced Filters](#header-advanced-filters).
     + domains (optional, list) ... Delimited list of recipient domains to include.
     + campaigns (optional, list) ... Delimited list of campaigns to include.
-    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability</span></a> Delimited list of subject campaigns to include. Supports deliverability metrics only.
+    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Delimited list of subject campaigns to include. Supports deliverability metrics only.
     + templates (optional, list) ... Delimited list of template IDs to include.
     + sending_ips (optional, list) ... Delimited list of sending IPs to include.
     + ip_pools (optional, list) ... Delimited list of IP pools to include.
@@ -788,7 +788,7 @@ Provides aggregate metrics grouped by sending domain over the time window specif
     + query_filters = (optional, string) ... An advanced query structure. See [Advanced Filters](#header-advanced-filters).
     + domains (optional, list) ... Delimited list of recipient domains to include.
     + campaigns (optional, list) ... Delimited list of campaigns to include.
-    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability</span></a> Delimited list of subject campaigns to include. Supports deliverability metrics only.
+    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Delimited list of subject campaigns to include. Supports deliverability metrics only.
     + templates (optional, list) ... Delimited list of template IDs to include.
     + sending_ips (optional, list) ... Delimited list of sending IPs to include.
     + ip_pools (optional, list) ... Delimited list of IP pools to include.
@@ -904,7 +904,7 @@ Provides aggregate metrics grouped by subaccount over the time window specified.
     + query_filters = (optional, string) ... An advanced query structure. See [Advanced Filters](#header-advanced-filters).
     + domains (optional, list) ... Delimited list of recipient domains to include.
     + campaigns (optional, list) ... Delimited list of campaigns to include.
-    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability</span></a> Delimited list of subject campaigns to include. Supports deliverability metrics only.
+    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Delimited list of subject campaigns to include. Supports deliverability metrics only.
     + templates (optional, list) ... Delimited list of template IDs to include.
     + sending_ips (optional, list) ... Delimited list of sending IPs to include.
     + ip_pools (optional, list) ... Delimited list of IP pools to include.
@@ -1020,7 +1020,7 @@ Provides aggregate metrics grouped by campaign over the time window specified.
     + query_filters = (optional, string) ... An advanced query structure. See [Advanced Filters](#header-advanced-filters).
     + domains (optional, list) ... Delimited list of recipient domains to include.
     + campaigns (optional, list) ... Delimited list of campaigns to include.
-    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability</span></a> Delimited list of subject campaigns to include. Supports deliverability metrics only.
+    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Delimited list of subject campaigns to include. Supports deliverability metrics only.
     + templates (optional, list) ... Delimited list of template IDs to include.
     + sending_ips (optional, list) ... Delimited list of sending IPs to include.
     + ip_pools (optional, list) ... Delimited list of IP pools to include.
@@ -1124,7 +1124,7 @@ Provides aggregate metrics grouped by template over the time window specified.
     + query_filters = (optional, string) ... An advanced query structure. See [Advanced Filters](#header-advanced-filters).
     + domains (optional, list) ... Delimited list of recipient domains to include.
     + campaigns (optional, list) ... Delimited list of campaigns to include.
-    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability</span></a> Delimited list of subject campaigns to include. Supports deliverability metrics only.
+    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Delimited list of subject campaigns to include. Supports deliverability metrics only.
     + templates (optional, list) ... Delimited list of template IDs to include.
     + sending_ips (optional, list) ... Delimited list of sending IPs to include.
     + ip_pools (optional, list) ... Delimited list of IP pools to include.
@@ -1219,7 +1219,7 @@ Provides aggregate metrics grouped by template over the time window specified.
         
 ### Metrics by Subject Campaign [GET /v1/metrics/deliverability/subject-campaign{?from,to,delimiter,domains,campaigns,templates,sending_ips,ip_pools,sending_domains,subaccounts,precision,metrics,timezone,limit,order_by}]
 
-Note: Only available to SparkPost <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability</span></a> customers
+Note: Only available to SparkPost <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> customers
 
 
 Provides aggregate metrics grouped by deliverability subject campaign over the time window specified.
@@ -1231,7 +1231,7 @@ Provides aggregate metrics grouped by deliverability subject campaign over the t
     + query_filters = (optional, string) ... An advanced query structure. See [Advanced Filters](#header-advanced-filters).
     + domains (optional, list) ... Delimited list of recipient domains to include.
     + campaigns (optional, list) ... Delimited list of campaigns to include.
-    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability</span></a> Delimited list of subject campaigns to include. Supports deliverability metrics only.
+    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Delimited list of subject campaigns to include. Supports deliverability metrics only.
     + templates (optional, list) ... Delimited list of template IDs to include.
     + sending_ips (optional, list) ... Delimited list of sending IPs to include.
     + ip_pools (optional, list) ... Delimited list of IP pools to include.
@@ -1312,7 +1312,7 @@ in the world.
     + query_filters = (optional, string) ... An advanced query structure. See [Advanced Filters](#header-advanced-filters).
     + domains (optional, list) ... Delimited list of recipient domains to include.
     + campaigns (optional, list) ... Delimited list of campaigns to include.
-    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability</span></a> Delimited list of subject campaigns to include. Supports deliverability metrics only.
+    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Delimited list of subject campaigns to include. Supports deliverability metrics only.
     + templates (optional, list) ... Delimited list of template IDs to include.
     + sending_ips (optional, list) ... Delimited list of sending IPs to include.
     + ip_pools (optional, list) ... Delimited list of IP pools to include.
@@ -1416,7 +1416,7 @@ Provides deliverability metrics ordered by a precision of time.
     + query_filters = (optional, string) ... An advanced query structure. See [Advanced Filters](#header-advanced-filters).
     + domains (optional, list `gmail.com,yahoo.com,hotmail.com`) ... Delimited list of domains for filtering.
     + campaigns (optional, list, `summerSale,promotionX`) ... Delimited list of campaigns for filtering.
-    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability</span></a> Delimited list of subject campaigns to include. Supports deliverability metrics only.    
+    + subject_campaigns (optional, list) ... <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Delimited list of subject campaigns to include. Supports deliverability metrics only.    
     + templates (optional, list) ... Delimited list of template IDs to include.
     + sending_ips (optional, list) ... Delimited list of sending IPs to include.
     + ip_pools (optional, list, `ip-pool-1,ip-pool-2,ip-pool-3`) ... Delimited list of IP pools to include.

--- a/content/api/metrics.apib
+++ b/content/api/metrics.apib
@@ -383,6 +383,7 @@ aggregate data, which can be used as "group by" qualifiers.
     + precision = `1min` (optional, enum) ...
 
         Precision of the time window (`from`, `to`) bounds. All values valid up to a 24 hour window, except for `hour` which is also valid up a 31 day window.
+        The `day` precision will return data in UTC regardless of the specified timezone.
         See: [Precision Parameter](#header-precision-parameter).
 
         + Values
@@ -390,6 +391,7 @@ aggregate data, which can be used as "group by" qualifiers.
             + `5min`
             + `15min`
             + `hour`
+            + `day`
 
     + metrics (required, list, `count_targeted,count_injected,count_rejected,count_sent`) ... Delimited list of metrics for filtering.
 
@@ -431,7 +433,7 @@ aggregate data, which can be used as "group by" qualifiers.
             + `count_moved_to_inbox`
             + `count_moved_to_spam`
 
-    + timezone =`UTC` (optional, string) ... Standard timezone identification string.
+    + timezone =`UTC` (optional, string) ... Standard timezone identification string. The `day` precision will return data in UTC regardless of the specified timezone.
 
 + Request
 
@@ -482,6 +484,7 @@ Provides aggregate metrics grouped by domain over the time window specified.
     + precision = `1min` (optional, enum) ...
 
         Precision of the time window (`from`, `to`) bounds. All values valid up to a 24 hour window, except for `hour` which is also valid up a 31 day window.
+        The `day` precision will return data in UTC regardless of the specified timezone.
         See: [Precision Parameter](#header-precision-parameter).
 
         + Values
@@ -489,6 +492,7 @@ Provides aggregate metrics grouped by domain over the time window specified.
             + `5min`
             + `15min`
             + `hour`
+            + `day`
 
     + metrics (required, list, `count_targeted,count_injected,count_rejected,count_sent`) ... Delimited list of metrics for filtering.
 
@@ -530,7 +534,7 @@ Provides aggregate metrics grouped by domain over the time window specified.
             + `count_moved_to_inbox`
             + `count_moved_to_spam`
 
-    + timezone =`UTC` (optional, string) ... Standard timezone identification string.
+    + timezone =`UTC` (optional, string) ... Standard timezone identification string. The `day` precision will return data in UTC regardless of the specified timezone.
     + limit=1000 (optional, int, `5`) ... Maximum number of results to return between 1 and 10000, inclusive.
     + order_by (optional, string) - Metric by which to order results.
         + Sample: count_injected
@@ -585,6 +589,7 @@ Provides aggregate metrics grouped by sending IP over the time window specified.
     + precision = `1min` (optional, enum) ...
 
         Precision of the time window (`from`, `to`) bounds. All values valid up to a 24 hour window, except for `hour` which is also valid up a 31 day window.
+        The `day` precision will return data in UTC regardless of the specified timezone.
         See: [Precision Parameter](#header-precision-parameter).
 
         + Values
@@ -592,6 +597,7 @@ Provides aggregate metrics grouped by sending IP over the time window specified.
             + `5min`
             + `15min`
             + `hour`
+            + `day`
 
     + metrics (required, list, `count_targeted`) ... Delimited list of metrics for filtering.
         
@@ -633,7 +639,7 @@ Provides aggregate metrics grouped by sending IP over the time window specified.
             + `count_moved_to_inbox`
             + `count_moved_to_spam`
 
-    + timezone =`UTC` (optional, string) ... Standard timezone identification string.
+    + timezone =`UTC` (optional, string) ... Standard timezone identification string. The `day` precision will return data in UTC regardless of the specified timezone.
     + limit=1000 (optional, int, `5`) ... Maximum number of results to return between 1 and 10000, inclusive.
     + order_by (optional, string) - Metric by which to order results.
         + Sample: count_injected
@@ -688,6 +694,7 @@ Provides aggregate metrics grouped by IP pool over the time window specified.
     + precision = `1min` (optional, enum) ...
 
         Precision of the time window (`from`, `to`) bounds. All values valid up to a 24 hour window, except for `hour` which is also valid up a 31 day window.
+        The `day` precision will return data in UTC regardless of the specified timezone.
         See: [Precision Parameter](#header-precision-parameter).
 
         + Values
@@ -695,6 +702,7 @@ Provides aggregate metrics grouped by IP pool over the time window specified.
             + `5min`
             + `15min`
             + `hour`
+            + `day`
 
     + metrics (required, list, `count_targeted`) ... Delimited list of metrics for filtering.
         
@@ -735,7 +743,7 @@ Provides aggregate metrics grouped by IP pool over the time window specified.
             + `count_spam_seed`
             + `count_moved_to_inbox`
             + `count_moved_to_spam`
-    + timezone =`UTC` (optional, string) ... Standard timezone identification string.
+    + timezone =`UTC` (optional, string) ... Standard timezone identification string. The `day` precision will return data in UTC regardless of the specified timezone.
     + limit = 1000 (optional, int, `5`) ... Maximum number of results to return between 1 and 10000, inclusive.
     + order_by (optional, string) - Metric by which to order results.
         + Sample: count_injected
@@ -789,6 +797,7 @@ Provides aggregate metrics grouped by sending domain over the time window specif
     + precision = `1min` (optional, enum) ...
 
         Precision of the time window (`from`, `to`) bounds. All values valid up to a 24 hour window, except for `hour` which is also valid up a 31 day window.
+        The `day` precision will return data in UTC regardless of the specified timezone.
         See: [Precision Parameter](#header-precision-parameter).
 
         + Values
@@ -796,6 +805,7 @@ Provides aggregate metrics grouped by sending domain over the time window specif
             + `5min`
             + `15min`
             + `hour`
+            + `day`
 
     + metrics (required, list, `count_targeted`) ... Delimited list of metrics for filtering.
         
@@ -836,7 +846,7 @@ Provides aggregate metrics grouped by sending domain over the time window specif
             + `count_spam_seed`
             + `count_moved_to_inbox`
             + `count_moved_to_spam`
-    + timezone =`UTC` (optional, string) ... Standard timezone identification string.
+    + timezone =`UTC` (optional, string) ... Standard timezone identification string. The `day` precision will return data in UTC regardless of the specified timezone.
     + limit=1000 (optional, int, `5`) ... Maximum number of results to return between 1 and 10000, inclusive.
     + order_by (optional, string) - Metric by which to order results.
         + Sample: count_injected
@@ -903,6 +913,7 @@ Provides aggregate metrics grouped by subaccount over the time window specified.
     + precision = `1min` (optional, enum) ...
 
         Precision of the time window (`from`, `to`) bounds. All values valid up to a 24 hour window, except for `hour` which is also valid up a 31 day window.
+        The `day` precision will return data in UTC regardless of the specified timezone.
         See: [Precision Parameter](#header-precision-parameter).
 
         + Values
@@ -910,6 +921,7 @@ Provides aggregate metrics grouped by subaccount over the time window specified.
             + `5min`
             + `15min`
             + `hour`
+            + `day`
 
     + metrics (required, list, `count_targeted`) ... Delimited list of metrics for filtering.
         
@@ -950,7 +962,7 @@ Provides aggregate metrics grouped by subaccount over the time window specified.
             + `count_spam_seed`
             + `count_moved_to_inbox`
             + `count_moved_to_spam`
-    + timezone =`UTC` (optional, string) ... Standard timezone identification string.
+    + timezone =`UTC` (optional, string) ... Standard timezone identification string. The `day` precision will return data in UTC regardless of the specified timezone.
     + limit=1000 (optional, int, `5`) ... Maximum number of results to return between 1 and 10000, inclusive.
     + order_by (optional, string) - Metric by which to order results.
         + Sample: count_injected
@@ -1017,6 +1029,7 @@ Provides aggregate metrics grouped by campaign over the time window specified.
     + precision = `1min` (optional, enum) ...
 
         Precision of the time window (`from`, `to`) bounds. All values valid up to a 24 hour window, except for `hour` which is also valid up a 31 day window.
+        The `day` precision will return data in UTC regardless of the specified timezone.
         See: [Precision Parameter](#header-precision-parameter).
 
         + Values
@@ -1024,6 +1037,7 @@ Provides aggregate metrics grouped by campaign over the time window specified.
             + `5min`
             + `15min`
             + `hour`
+            + `day`
 
     + metrics (required, list) ... Delimited list of metrics for filtering.
 
@@ -1065,7 +1079,7 @@ Provides aggregate metrics grouped by campaign over the time window specified.
             + `count_moved_to_inbox`
             + `count_moved_to_spam`
 
-    + timezone =`UTC` (optional, string) ... Standard timezone identification string.
+    + timezone =`UTC` (optional, string) ... Standard timezone identification string. The `day` precision will return data in UTC regardless of the specified timezone.
     + limit=1000 (optional, int, `5`) ... Maximum number of results to return between 1 and 10000, inclusive.
     + order_by (optional, string) - Metric by which to order results.
     + Sample: count_injected
@@ -1119,6 +1133,7 @@ Provides aggregate metrics grouped by template over the time window specified.
     + precision = `1min` (optional, enum) ...
 
         Precision of the time window (`from`, `to`) bounds. All values valid up to a 24 hour window, except for `hour` which is also valid up a 31 day window.
+        The `day` precision will return data in UTC regardless of the specified timezone.
         See: [Precision Parameter](#header-precision-parameter).
 
         + Values
@@ -1126,6 +1141,7 @@ Provides aggregate metrics grouped by template over the time window specified.
             + `5min`
             + `15min`
             + `hour`
+            + `day`
 
     + metrics (required, list) ... Delimited list of metrics for filtering.
 
@@ -1167,7 +1183,7 @@ Provides aggregate metrics grouped by template over the time window specified.
             + `count_moved_to_inbox`
             + `count_moved_to_spam`
 
-    + timezone =`UTC` (optional, string) ... Standard timezone identification string.
+    + timezone =`UTC` (optional, string) ... Standard timezone identification string. The `day` precision will return data in UTC regardless of the specified timezone.
     + limit=1000 (optional, int, `5`) ... Maximum number of results to return between 1 and 10000, inclusive.
     + order_by (optional, string) - Metric by which to order results.
         + Sample: count_injected
@@ -1224,6 +1240,7 @@ Provides aggregate metrics grouped by deliverability subject campaign over the t
     + precision = `1min` (optional, enum) ...
 
         Precision of the time window (`from`, `to`) bounds. All values valid up to a 24 hour window, except for `hour` which is also valid up a 31 day window.
+        The `day` precision will return data in UTC regardless of the specified timezone.
         See: [Precision Parameter](#header-precision-parameter).
 
         + Values
@@ -1231,6 +1248,7 @@ Provides aggregate metrics grouped by deliverability subject campaign over the t
             + `5min`
             + `15min`
             + `hour`
+            + `day`
 
     + metrics (required, list) ... Delimited list of metrics for filtering. Supports deliverability metrics only.
 
@@ -1242,7 +1260,7 @@ Provides aggregate metrics grouped by deliverability subject campaign over the t
             + `count_moved_to_inbox`
             + `count_moved_to_spam`
 
-    + timezone =`UTC` (optional, string) ... Standard timezone identification string.
+    + timezone =`UTC` (optional, string) ... Standard timezone identification string. The `day` precision will return data in UTC regardless of the specified timezone.
     + limit=1000 (optional, int, `5`) ... Maximum number of results to return between 1 and 10000, inclusive.
     + order_by (optional, string) - Metric by which to order results.
         + Sample: count_inbox_panel
@@ -1303,6 +1321,7 @@ in the world.
     + precision = `1min` (optional, enum) ...
 
         Precision of the time window (`from`, `to`) bounds. All values valid up to a 24 hour window, except for `hour` which is also valid up a 31 day window.
+        The `day` precision will return data in UTC regardless of the specified timezone.
         See: [Precision Parameter](#header-precision-parameter).
 
         + Values
@@ -1310,6 +1329,7 @@ in the world.
             + `5min`
             + `15min`
             + `hour`
+            + `day`
 
     + metrics (required, list) ... Delimited list of metrics for filtering.
 
@@ -1351,7 +1371,7 @@ in the world.
             + `count_moved_to_inbox`
             + `count_moved_to_spam`
 
-    + timezone =`UTC` (optional, string) ... Standard timezone identification string.
+    + timezone =`UTC` (optional, string) ... Standard timezone identification string. The `day` precision will return data in UTC regardless of the specified timezone.
     + limit=1000 (optional, int, `5`) ... Maximum number of results to return between 1 and 10000, inclusive.
     + order_by (optional, string) - Metric by which to order results.
         + Sample: count_injected

--- a/content/api/metrics.apib
+++ b/content/api/metrics.apib
@@ -1403,7 +1403,7 @@ Provides deliverability metrics ordered by a precision of time.
     + ip_pools (optional, list, `ip-pool-1,ip-pool-2,ip-pool-3`) ... Delimited list of IP pools to include.
     + sending_domains (optional, list) ... Delimited list of sending domains to include.
     + subaccounts (optional, list) ... Delimited list of subaccount IDs to include.
-    + precision (optional, enum, `day`) ... Precision of timeseries data returned.
+    + precision (optional, enum, `day`) ... Precision of timeseries data returned. Precisions `day`, `week`, and `month` will return data in the UTC timezone regardless of the specified timezone.
 
         + Values
             + `1min`
@@ -1455,7 +1455,7 @@ Provides deliverability metrics ordered by a precision of time.
             + `count_moved_to_inbox`
             + `count_moved_to_spam`
 
-    + timezone = `UTC` (optional, string `America/New_York`) ... Standard timezone identification string.
+    + timezone = `UTC` (optional, string `America/New_York`) ... Standard timezone identification string. Precisions `day`, `week`, and `month` will return data in the UTC timezone regardless of the specified timezone.
 
 + Request
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10113,8 +10113,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -10132,13 +10131,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -10151,18 +10148,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -10265,8 +10259,7 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -10276,7 +10269,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -10289,20 +10281,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "1.2.5",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -10319,7 +10308,6 @@
         "mkdirp": {
           "version": "0.5.3",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -10375,8 +10363,7 @@
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -10401,8 +10388,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -10412,7 +10398,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -10481,8 +10466,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -10512,7 +10496,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -10530,7 +10513,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -10569,13 +10551,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3880,7 +3880,7 @@
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -3997,7 +3997,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE="
     },
     "arr-union": {
       "version": "3.1.0",
@@ -4267,7 +4267,7 @@
     "asn1.js": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+      "integrity": "sha1-ucK/WAXx5kqt7tbfOiv6+1pz9aA=",
       "requires": {
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
@@ -4507,7 +4507,7 @@
     "babel-generator": {
       "version": "6.26.1",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+      "integrity": "sha1-GERAjTuPDTWkBOp6wYDwh6YBvZA=",
       "requires": {
         "babel-messages": "^6.23.0",
         "babel-runtime": "^6.26.0",
@@ -4727,7 +4727,7 @@
     "babel-plugin-lodash": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-lodash/-/babel-plugin-lodash-3.3.4.tgz",
-      "integrity": "sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==",
+      "integrity": "sha1-T2hENYoTQLrtGCrb7/qN+ZZ7wZY=",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0-beta.49",
         "@babel/types": "^7.0.0-beta.49",
@@ -4932,7 +4932,7 @@
     "babel-plugin-transform-es2015-modules-commonjs": {
       "version": "6.26.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
-      "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
+      "integrity": "sha1-WKeThjqefKhwvcWogRF/+sJ9tvM=",
       "requires": {
         "babel-plugin-transform-strict-mode": "^6.24.1",
         "babel-runtime": "^6.26.0",
@@ -5391,7 +5391,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "requires": {
             "ms": "2.0.0"
           }
@@ -5399,7 +5399,7 @@
         "globals": {
           "version": "9.18.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+          "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo="
         },
         "ms": {
           "version": "2.0.0",
@@ -5449,7 +5449,7 @@
     "base": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
       "requires": {
         "cache-base": "^1.0.1",
         "class-utils": "^0.3.5",
@@ -5471,7 +5471,7 @@
         "is-accessor-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -5479,7 +5479,7 @@
         "is-data-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -5487,7 +5487,7 @@
         "is-descriptor": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -5943,7 +5943,7 @@
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -5952,7 +5952,7 @@
     "braces": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
       "requires": {
         "arr-flatten": "^1.1.0",
         "array-unique": "^0.3.2",
@@ -5983,7 +5983,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
         "buffer-xor": "^1.0.3",
@@ -5997,7 +5997,7 @@
     "browserify-cipher": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
-      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+      "integrity": "sha1-jWR0wbhwv9q807z8wZNKEOlPFfA=",
       "requires": {
         "browserify-aes": "^1.0.4",
         "browserify-des": "^1.0.0",
@@ -6007,7 +6007,7 @@
     "browserify-des": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
-      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+      "integrity": "sha1-OvTx9Zg5QDVy8cZiBDdfen9wPpw=",
       "requires": {
         "cipher-base": "^1.0.1",
         "des.js": "^1.0.0",
@@ -6041,7 +6041,7 @@
     "browserify-zlib": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
       "requires": {
         "pako": "~1.0.5"
       }
@@ -6068,7 +6068,7 @@
     "buffer-alloc": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "integrity": "sha1-iQ3ZDZI6hz4I4Q5f1RpX5bfM4Ow=",
       "requires": {
         "buffer-alloc-unsafe": "^1.1.0",
         "buffer-fill": "^1.0.0"
@@ -6077,7 +6077,7 @@
     "buffer-alloc-unsafe": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+      "integrity": "sha1-vX3CauKXLQ7aJTvgYdupkjScGfA="
     },
     "buffer-crc32": {
       "version": "0.2.13",
@@ -6183,7 +6183,7 @@
     "cache-base": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
       "requires": {
         "collection-visit": "^1.0.0",
         "component-emitter": "^1.2.1",
@@ -6589,7 +6589,7 @@
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -6598,7 +6598,7 @@
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
       "requires": {
         "arr-union": "^3.1.0",
         "define-property": "^0.2.5",
@@ -6619,7 +6619,7 @@
     "classnames": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+      "integrity": "sha1-Q5Nb/90pHzJtrQogUwmzjQD2UM4="
     },
     "clean-stack": {
       "version": "2.2.0",
@@ -6811,7 +6811,7 @@
     "common-tags": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
-      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw=="
+      "integrity": "sha1-jjFT5ULUo56bEFVENK+q+YlWqTc="
     },
     "commondir": {
       "version": "1.0.1",
@@ -6989,7 +6989,7 @@
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+      "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js="
     },
     "contentful-management": {
       "version": "7.7.0",
@@ -7191,7 +7191,7 @@
     "create-ecdh": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
-      "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+      "integrity": "sha1-yREbbzMEXEaX8UR4f5JUzcd8Rf8=",
       "requires": {
         "bn.js": "^4.1.0",
         "elliptic": "^6.0.0"
@@ -7212,7 +7212,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
         "cipher-base": "^1.0.1",
@@ -7224,7 +7224,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
         "cipher-base": "^1.0.3",
@@ -7296,7 +7296,7 @@
     "crypto-browserify": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+      "integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
       "requires": {
         "browserify-cipher": "^1.0.0",
         "browserify-sign": "^4.0.0",
@@ -7754,7 +7754,7 @@
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+      "integrity": "sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -7846,7 +7846,7 @@
     "define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
       "requires": {
         "is-descriptor": "^1.0.2",
         "isobject": "^3.0.1"
@@ -7855,7 +7855,7 @@
         "is-accessor-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -7863,7 +7863,7 @@
         "is-data-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -7871,7 +7871,7 @@
         "is-descriptor": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -8084,7 +8084,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "requires": {
         "bn.js": "^4.1.0",
@@ -8220,7 +8220,7 @@
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
-      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
+      "integrity": "sha1-PTH1AZGmdJ3RN1p/Ui6CPULlTto="
     },
     "domelementtype": {
       "version": "1.3.1",
@@ -8405,7 +8405,7 @@
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
         "once": "^1.4.0"
       }
@@ -8530,7 +8530,7 @@
     "envify": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/envify/-/envify-4.1.0.tgz",
-      "integrity": "sha512-IKRVVoAYr4pIx4yIWNsz9mOsboxlNXiu7TNBnem/K/uTHdkyzXWDzHCK7UTolqBbgaBz0tQHsD3YNls0uIIjiw==",
+      "integrity": "sha1-85rT251oAbTmtHi2ECjT8LaBn34=",
       "requires": {
         "esprima": "^4.0.0",
         "through": "~2.3.4"
@@ -8549,7 +8549,7 @@
     "errno": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+      "integrity": "sha1-RoTXF3mtOa8Xfj8AeZb3xnyFJhg=",
       "requires": {
         "prr": "~1.0.1"
       }
@@ -8557,7 +8557,7 @@
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -9250,7 +9250,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE="
     },
     "esquery": {
       "version": "1.4.0",
@@ -9270,7 +9270,7 @@
     "esrecurse": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
       "requires": {
         "estraverse": "^4.1.0"
       }
@@ -9330,7 +9330,7 @@
     "evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
       "requires": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
@@ -9385,7 +9385,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "requires": {
             "ms": "2.0.0"
           }
@@ -9600,7 +9600,7 @@
         "is-extendable": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "requires": {
             "is-plain-object": "^2.0.4"
           }
@@ -9630,7 +9630,7 @@
     "extglob": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
       "requires": {
         "array-unique": "^0.3.2",
         "define-property": "^1.0.0",
@@ -9661,7 +9661,7 @@
         "is-accessor-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -9669,7 +9669,7 @@
         "is-data-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -9677,7 +9677,7 @@
         "is-descriptor": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -10582,7 +10582,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -14487,7 +14487,7 @@
     "get-window": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/get-window/-/get-window-1.1.2.tgz",
-      "integrity": "sha512-yjWpFcy9fjhLQHW1dPtg9ga4pmizLY8y4ZSHdGrAQ1NU277MRhnGnnLPxe19X8W5lWVsCZz++5xEuNozWMVmTw==",
+      "integrity": "sha1-ZfuqmZ+4f4bqXTB3D0CXcHBE9H8=",
       "requires": {
         "get-document": "1"
       }
@@ -14962,7 +14962,7 @@
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -15239,7 +15239,7 @@
     "hast-util-to-mdast": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/hast-util-to-mdast/-/hast-util-to-mdast-1.2.0.tgz",
-      "integrity": "sha512-kYrD+weqqtBwqLHkEMh12YHXPzG1iuRm9NH3qVs7hwGTkE5QrhtdMahVN96JnRnb/MmdvfKCzK42ajgRKjQzNg==",
+      "integrity": "sha1-KBL3RChhhgQ9XVJt/JZP8Ca+B7c=",
       "requires": {
         "hast-util-has-property": "^1.0.0",
         "hast-util-is-element": "^1.0.0",
@@ -15535,7 +15535,7 @@
     "husky": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
-      "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
+      "integrity": "sha1-xp7XTi0neXaaF7qDmbVM4LY8EsM=",
       "dev": true,
       "requires": {
         "is-ci": "^1.0.10",
@@ -16146,7 +16146,7 @@
     "invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "integrity": "sha1-YQ88ksk1nOHbYW5TgAjSP/NRWOY=",
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -16248,7 +16248,7 @@
     "is-callable": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha1-HhrfIZ4e62hNaR+dagX/DTCiTXU="
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
     },
     "is-ci": {
       "version": "2.0.0",
@@ -16315,7 +16315,7 @@
     "is-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
       "requires": {
         "is-accessor-descriptor": "^0.1.6",
         "is-data-descriptor": "^0.1.4",
@@ -16325,7 +16325,7 @@
         "kind-of": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0="
         }
       }
     },
@@ -16530,7 +16530,7 @@
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
       "requires": {
         "isobject": "^3.0.1"
       }
@@ -16674,7 +16674,7 @@
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+      "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0="
     },
     "is-word-character": {
       "version": "1.0.3",
@@ -16939,7 +16939,7 @@
     "json-loader": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
-      "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w=="
+      "integrity": "sha1-3KFKcCNf+C8KyaOr62DTN6NlGF0="
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -17030,7 +17030,7 @@
     "kebab-hash": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/kebab-hash/-/kebab-hash-0.1.2.tgz",
-      "integrity": "sha512-BTZpq3xgISmQmAVzkISy4eUutsUA7s4IEFlCwOBJjvSFOwyR7I+fza+tBc/rzYWK/NrmFHjfU1IhO3lu29Ib/w==",
+      "integrity": "sha1-37eUm6NNjnARTqfYPiZuXipKuqw=",
       "requires": {
         "lodash.kebabcase": "^4.1.1"
       }
@@ -17277,7 +17277,7 @@
     "lodash-webpack-plugin": {
       "version": "0.11.5",
       "resolved": "https://registry.npmjs.org/lodash-webpack-plugin/-/lodash-webpack-plugin-0.11.5.tgz",
-      "integrity": "sha512-QWfEIYxpixOdbd6KBe5g6MDWcyTgP3trDXwKHFqTlXrWiLcs/67fGQ0IWeRyhWlTITQIgMpJAYd2oeIztuV5VA==",
+      "integrity": "sha1-xL0GS09WHD+CP6WYK96xLEdTkLk=",
       "requires": {
         "lodash": "^4.17.4"
       }
@@ -17437,7 +17437,7 @@
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+      "integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8="
     },
     "lowlight": {
       "version": "1.12.1",
@@ -17543,7 +17543,7 @@
     "md5-file": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/md5-file/-/md5-file-3.2.3.tgz",
-      "integrity": "sha512-3Tkp1piAHaworfcCgH0jKbTvj1jWWFgbvh2cXaNCgHwyTCBxxvD1Y04rmfpvdPm1P4oXMOpm6+2H7sr7v9v8Fw==",
+      "integrity": "sha1-+bzrlB7KIhSkwHJ/XnADFOdw8G8=",
       "requires": {
         "buffer-alloc": "^1.1.0"
       }
@@ -17851,7 +17851,7 @@
     "micromatch": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
       "requires": {
         "arr-diff": "^4.0.0",
         "array-unique": "^0.3.2",
@@ -17871,7 +17871,7 @@
     "miller-rabin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
       "requires": {
         "bn.js": "^4.0.0",
         "brorand": "^1.0.1"
@@ -17898,7 +17898,7 @@
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+      "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI="
     },
     "mimic-response": {
       "version": "1.0.1",
@@ -17986,12 +17986,12 @@
     "minim-api-description": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/minim-api-description/-/minim-api-description-0.8.1.tgz",
-      "integrity": "sha512-Tby/4oxIGD+bHimYFrOuQjA2h0jbyjIt9EmCFfyAOpkDjGkFWCXvfo137w49+ToUMj30cYNGM6TXyVoX3Zuuww=="
+      "integrity": "sha1-POAD2yruAW2SB/mcK9kNu6NnZDk="
     },
     "minim-parse-result": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/minim-parse-result/-/minim-parse-result-0.10.1.tgz",
-      "integrity": "sha512-FZ9uZSsJOtGQ1fPjHOoT291J0K53BlL4XphiPIZc4zwNyrlS0m7o/QhupeAJ7xKz+6FNJJDKxfzw7LijPK0WBw==",
+      "integrity": "sha1-mjjScUyCTcSGFRnS8yGo4MsukVQ=",
       "requires": {
         "minim-api-description": "^0.8.1"
       }
@@ -17999,7 +17999,7 @@
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+      "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc="
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
@@ -18009,7 +18009,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -18194,7 +18194,7 @@
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
-      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "integrity": "sha1-uHqKpPwN6P5r6IiVs4mD/yZb0Rk=",
       "requires": {
         "arr-diff": "^4.0.0",
         "array-unique": "^0.3.2",
@@ -18240,7 +18240,7 @@
     "netlify-cms": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/netlify-cms/-/netlify-cms-1.9.3.tgz",
-      "integrity": "sha512-DNhD5BK7VaJ3zWTXOkcqwCIZUq061PUOGHFj43y6udUPsbDD0cTzB9J9EH4loNzuR3MTW+mTESmKmU55jVaVvw==",
+      "integrity": "sha1-9l2Ct3eZg+Rx/EAwfJAO2AncKBk=",
       "requires": {
         "classnames": "^2.2.5",
         "create-react-class": "^15.6.0",
@@ -18435,7 +18435,7 @@
         "unified": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
-          "integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
+          "integrity": "sha1-f71jD3GRJtZ9QMZEt+P2FwNfbbo=",
           "requires": {
             "bail": "^1.0.0",
             "extend": "^3.0.0",
@@ -19359,7 +19359,7 @@
     "p-limit": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
       "requires": {
         "p-try": "^1.0.0"
       }
@@ -19894,7 +19894,7 @@
     "polished": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/polished/-/polished-1.9.3.tgz",
-      "integrity": "sha512-4NmSD7fMFlM8roNxs7YXPv7UFRbYzb0gufR5zBxJLRzY54+zFsavxBo6zsQzP9ep6Hh3pC2pTyrpSTBEaB6IkQ=="
+      "integrity": "sha1-1huKDEYk7+MeJYP/JKNYkytrdeE="
     },
     "portfinder": {
       "version": "1.0.28",
@@ -20823,7 +20823,7 @@
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+      "integrity": "sha1-I4Hts2ifelPWUxkAYPz4ItLzaP8="
     },
     "probe-image-size": {
       "version": "4.1.1",
@@ -20856,7 +20856,7 @@
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
       "requires": {
         "asap": "~2.0.3"
       }
@@ -20975,7 +20975,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
     },
     "pupa": {
       "version": "2.1.1",
@@ -21039,7 +21039,7 @@
     "randomfill": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
-      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "integrity": "sha1-ySGW/IarQr6YPxvzF3giSTHWFFg=",
       "requires": {
         "randombytes": "^2.0.5",
         "safe-buffer": "^5.1.0"
@@ -21076,7 +21076,7 @@
     "rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "integrity": "sha1-zZJL9SAKB1uDwYjNa54hG3/A0+0=",
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -21098,7 +21098,7 @@
     "react-aria-menubutton": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/react-aria-menubutton/-/react-aria-menubutton-5.1.1.tgz",
-      "integrity": "sha512-ceBjPvuqwM2jnRFsfMlpfPdyqQ5cz4STNH7NlKpxStr2uETB/zQ2sHiIUMTuqSuOszU1kgUB2vm3aVn3xdjhcA==",
+      "integrity": "sha1-VrHzb/Q95I36HqsW6fXvwaY9wKk=",
       "requires": {
         "focus-group": "^0.3.1",
         "prop-types": "^15.6.0",
@@ -21487,7 +21487,7 @@
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+      "integrity": "sha1-TxonOv38jzSIqMUWv9p4+HI1I2I="
     },
     "react-modal": {
       "version": "3.9.1",
@@ -21518,7 +21518,7 @@
     "react-portal": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/react-portal/-/react-portal-3.2.0.tgz",
-      "integrity": "sha512-avb1FreAZAVCvNNyS2dCpxZiPYPJnAasHYPxdVBTROgNFeI+KSb+OoMHNsC1GbDawESCriPwCX+qKua6WSPIFw==",
+      "integrity": "sha1-QiThmysF1cvnMKe6DjTsdYXeAEM=",
       "requires": {
         "prop-types": "^15.5.8"
       }
@@ -21544,7 +21544,7 @@
     "react-router": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz",
-      "integrity": "sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==",
+      "integrity": "sha1-qtpK7xTICcsuaGsFzuR0IjRQbE4=",
       "requires": {
         "history": "^4.7.2",
         "hoist-non-react-statics": "^2.5.0",
@@ -21586,7 +21586,7 @@
     "react-router-dom": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.3.1.tgz",
-      "integrity": "sha512-c/MlywfxDdCp7EnB7YfPMOfMD3tOtIjrQlj/CKfNMBxdmpJP8xcz5P/UAFn3JbnQCNUxsHyVVqllF9LhgVyFCA==",
+      "integrity": "sha1-TCYZ/CTE+ofJ/Rj0+0pD/mP71cY=",
       "requires": {
         "history": "^4.7.2",
         "invariant": "^2.2.4",
@@ -21619,7 +21619,7 @@
     "react-scroll-sync": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/react-scroll-sync/-/react-scroll-sync-0.4.1.tgz",
-      "integrity": "sha512-fB3p012TQ2zghAR96chXgN8RPThsOG6aR/pjVgYmVawKvzI+Q60ae3Odg96TkrFNV5quc0KR2iyLwNqEU1AbUw=="
+      "integrity": "sha1-8nSfkMehDCrLnOg6KpmMu4h3Diw="
     },
     "react-side-effect": {
       "version": "1.1.5",
@@ -21633,7 +21633,7 @@
     "react-sortable-hoc": {
       "version": "0.6.8",
       "resolved": "https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-0.6.8.tgz",
-      "integrity": "sha512-sUUAtNdV84AKZ2o+F5lVOOFWcyWG6aGDkNFgHoieB1zFLeWLWENkix06asPS4/GhigfuRh06aZix1j3Qx8+NSQ==",
+      "integrity": "sha1-sIVi9XDXxB9uOT/KUoedLruRGOk=",
       "requires": {
         "babel-runtime": "^6.11.6",
         "invariant": "^2.2.1",
@@ -21654,7 +21654,7 @@
     "react-sticky": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/react-sticky/-/react-sticky-6.0.3.tgz",
-      "integrity": "sha512-LNH4UJlRatOqo29/VHxDZOf6fwbgfgcHO4mkEFvrie5FuaZCSTGtug5R8NGqJ0kSnX8gHw8qZN37FcvnFBJpTQ==",
+      "integrity": "sha1-ehi2Q+GGPaET1/cDYRjSp12ezeQ=",
       "requires": {
         "prop-types": "^15.5.8",
         "raf": "^3.3.0"
@@ -21671,7 +21671,7 @@
     "react-textarea-autosize": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-5.2.1.tgz",
-      "integrity": "sha512-bx6z2I35aapr71ggw2yZIA4qhmqeTa4ZVsSaTeFvtf9kfcZppDBh2PbMt8lvbdmzEk7qbSFhAxR9vxEVm6oiMg==",
+      "integrity": "sha1-K3j5BnGA9BsIrFn3jxWBq63WHlQ=",
       "requires": {
         "prop-types": "^15.6.0"
       }
@@ -21694,12 +21694,12 @@
     "react-toggled": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/react-toggled/-/react-toggled-1.2.7.tgz",
-      "integrity": "sha512-3am1uA5ZzDwUkReEuUkK+fJ0DAYcGiLraWEPqXfL1kKD/NHbbB7fB/t+5FflMGd+FA6n9hih1es4pui1yzKi0w=="
+      "integrity": "sha1-vhtyBYNY3R/+EYEeRCflyc8UDBA="
     },
     "react-topbar-progress-indicator": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-topbar-progress-indicator/-/react-topbar-progress-indicator-2.0.0.tgz",
-      "integrity": "sha512-QEKsnwkjMvb10h7k+cFm0UeeVcRRIGhOJNqMQAbDyzSifPvlePk0KIcUb9dof2SkW7E5GaSxGsmXSpaFTYn43A==",
+      "integrity": "sha1-z7S0vYWjL5Da50M43QCNOggjVdM=",
       "requires": {
         "topbar": "^0.1.3"
       }
@@ -21837,7 +21837,7 @@
     "redux-notifications": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/redux-notifications/-/redux-notifications-4.0.1.tgz",
-      "integrity": "sha512-mRVaEcsvu5B4P8x8kW0uY83EQqaWL/0+/NvL4bdbHGJVg+Rwx54MgBU1s+tB6RAA2E6NX/DmQrO4EbFDcQSi+w==",
+      "integrity": "sha1-ZsnxG7HrN1xjO+qvc3gAXqswO/s=",
       "requires": {
         "object-assign": "^4.1.1",
         "prop-types": "^15.5.10",
@@ -21848,7 +21848,7 @@
         "react-transition-group": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.2.1.tgz",
-          "integrity": "sha512-CWaL3laCmgAFdxdKbhhps+c0HRGF4c+hdM4H23+FI1QBNUyx/AMeIJGWorehPNSaKnQNOAxL7PQmqMu78CDj3Q==",
+          "integrity": "sha1-4R9yslf5IbITIpp3TfRmEjRsfKY=",
           "requires": {
             "chain-function": "^1.0.0",
             "dom-helpers": "^3.2.0",
@@ -21872,7 +21872,7 @@
     "regenerate": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
+      "integrity": "sha1-SoVuxLVuQHfFV1icroXnpMiGmhE="
     },
     "regenerate-unicode-properties": {
       "version": "8.2.0",
@@ -21913,7 +21913,7 @@
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
       "requires": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
@@ -22477,7 +22477,7 @@
     "remark-parse": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-5.0.0.tgz",
-      "integrity": "sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==",
+      "integrity": "sha1-TAd/nkmQRNHVwT+A16mM97koXZU=",
       "requires": {
         "collapse-white-space": "^1.0.2",
         "is-alphabetical": "^1.0.0",
@@ -22707,7 +22707,7 @@
     "ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+      "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w="
     },
     "retext-english": {
       "version": "3.0.4",
@@ -22757,7 +22757,7 @@
     "ripemd160": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "integrity": "sha1-ocGm9iR1FXe6XQeRTLyShQWFiQw=",
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
@@ -22808,7 +22808,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -22821,7 +22821,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
     },
     "sanitize-filename": {
       "version": "1.6.2",
@@ -23016,7 +23016,7 @@
     "semaphore": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz",
-      "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA=="
+      "integrity": "sha1-qq2LhrIP6OmzKxbcLuaCqM0mqKo="
     },
     "semver": {
       "version": "5.7.0",
@@ -23198,7 +23198,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
         "inherits": "^2.0.1",
@@ -23218,7 +23218,7 @@
     "shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+      "integrity": "sha1-GI1SHelbkIdAT9TctosT3wrk5/g="
     },
     "sharp": {
       "version": "0.25.4",
@@ -23348,7 +23348,7 @@
     "slate": {
       "version": "0.30.7",
       "resolved": "https://registry.npmjs.org/slate/-/slate-0.30.7.tgz",
-      "integrity": "sha512-pETHjdOXB4IVukjw56eKjFACwio6V1SBu3lK+kb3Jvg0qc9Uy1bikG2Nd7STpE29v8x1HbQ56Ys+g6Ois9yQMA==",
+      "integrity": "sha1-mLXk2FKXdery5+OiMG24zEkDR3I=",
       "requires": {
         "debug": "^2.3.2",
         "direction": "^0.1.5",
@@ -23363,7 +23363,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "requires": {
             "ms": "2.0.0"
           }
@@ -23401,7 +23401,7 @@
     "slate-plain-serializer": {
       "version": "0.4.16",
       "resolved": "https://registry.npmjs.org/slate-plain-serializer/-/slate-plain-serializer-0.4.16.tgz",
-      "integrity": "sha512-eiXUaes5jhZ/T4RCXKcO8nJ6cOc//Mg9eE/xJeaeq6afM/mEq4nd4EGHnPvWy2Ue8jgePDXK1OTg41aTmuy6vQ==",
+      "integrity": "sha1-7/J3tYlD4TCQURTH2kMaswfLTB4=",
       "requires": {
         "slate-dev-logger": "^0.1.36"
       }
@@ -23414,7 +23414,7 @@
     "slate-react": {
       "version": "0.10.11",
       "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.10.11.tgz",
-      "integrity": "sha512-rwcysp/WkSuoNds2paHV+adqpPS3iZ2nY4X+uxDh8wCXkgCY3fYmLpvOcOmVS0FJHIfF3PR8PZ6UWoSHRI9tAA==",
+      "integrity": "sha1-X7+/DaLdcm30aNeI0r2B3VeKFaM=",
       "requires": {
         "debug": "^2.3.2",
         "get-window": "^1.1.1",
@@ -23435,7 +23435,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "requires": {
             "ms": "2.0.0"
           }
@@ -23450,7 +23450,7 @@
     "slate-soft-break": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/slate-soft-break/-/slate-soft-break-0.6.1.tgz",
-      "integrity": "sha512-PTujwU6B8vKO86Yqj2TXcryxkal6PBmFrUhZwZF6fQlhlLUaJAMYQX60blGvO7tncDxyofxxIkBKdGdjL3JldA=="
+      "integrity": "sha1-tenM88uHYWjBAmZCgnTiUjsNPdk="
     },
     "slice-ansi": {
       "version": "2.1.0",
@@ -23477,7 +23477,7 @@
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
-      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
       "requires": {
         "base": "^0.11.1",
         "debug": "^2.2.0",
@@ -23492,7 +23492,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "requires": {
             "ms": "2.0.0"
           }
@@ -23523,7 +23523,7 @@
     "snapdragon-node": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
       "requires": {
         "define-property": "^1.0.0",
         "isobject": "^3.0.0",
@@ -23541,7 +23541,7 @@
         "is-accessor-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -23549,7 +23549,7 @@
         "is-data-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -23557,7 +23557,7 @@
         "is-descriptor": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -23569,7 +23569,7 @@
     "snapdragon-util": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
       "requires": {
         "kind-of": "^3.2.0"
       },
@@ -23876,7 +23876,7 @@
     "spdx-expression-parse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
       "requires": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -23950,7 +23950,7 @@
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
       "requires": {
         "extend-shallow": "^3.0.0"
       }
@@ -24144,7 +24144,7 @@
     "stream-http": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
-      "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
+      "integrity": "sha1-stJCRpKIpaJ+xP6JM6z2I95lFPw=",
       "requires": {
         "builtin-status-codes": "^3.0.0",
         "inherits": "^2.0.1",
@@ -24211,7 +24211,7 @@
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
@@ -24334,7 +24334,7 @@
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -24501,7 +24501,7 @@
     },
     "styled-normalize": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/styled-normalize/-/styled-normalize-4.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/styled-normalize/-/styled-normalize-4.0.0.tgz",
       "integrity": "sha512-lch9l2HKxhTvCaBwVigkBGQywMO4dSwX63yZj578W32CBSHKVCLq4huzZ++ByRVP/vpxMb1GRVZIVW+ioRZkuw=="
     },
     "stylehacks": {
@@ -24691,7 +24691,7 @@
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+      "integrity": "sha1-wiaIrtTqs83C3+rLtWFmBWCgCAQ="
     },
     "sync-fetch": {
       "version": "0.3.0",
@@ -25133,7 +25133,7 @@
     "to-regex": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
-      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
       "requires": {
         "define-property": "^2.0.2",
         "extend-shallow": "^3.0.2",
@@ -25163,12 +25163,12 @@
     "toml-j0.4": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/toml-j0.4/-/toml-j0.4-1.1.1.tgz",
-      "integrity": "sha512-lYK5otg0+cto8YmsWcPEfeiTiC/VU6P6HA6ooaYI9K/KYT24Jg0BrYtRZK1K3cwakSMyh6nttfJL9RmQH0gyCg=="
+      "integrity": "sha1-6wxwNIYJoCY7sdbko90ZHcymCGY="
     },
     "tomlify-j0.4": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tomlify-j0.4/-/tomlify-j0.4-3.0.0.tgz",
-      "integrity": "sha512-2Ulkc8T7mXJ2l0W476YC/A209PR38Nw8PuaCNtk9uI3t1zzFdGQeWYGQvmj2PZkVvRC/Yoi4xQKMRnWc/N29tQ=="
+      "integrity": "sha1-mUFNRSaMOjuL84voIUW3u6NLdHM="
     },
     "topbar": {
       "version": "0.1.3",
@@ -25360,7 +25360,7 @@
     "typeface-source-code-pro": {
       "version": "0.0.54",
       "resolved": "https://registry.npmjs.org/typeface-source-code-pro/-/typeface-source-code-pro-0.0.54.tgz",
-      "integrity": "sha512-rzCoj8PrX55xuBXJPlSGIFzRdWSRjJyvgVjRrDFEdlej2yFaKcff8O7AmNmHApqMmIreYNS563eb3ZjdSgRqpg=="
+      "integrity": "sha1-Ugx2JasXxDQKODsi0aB9c2NJ7Ls="
     },
     "ua-parser-js": {
       "version": "0.7.20",
@@ -25677,7 +25677,7 @@
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+      "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY="
     },
     "unixify": {
       "version": "1.0.0",
@@ -25751,7 +25751,7 @@
     "update-notifier": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
-      "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
+      "integrity": "sha1-0HRFk+E/Fh5AassdlAi3LK0Ir/Y=",
       "requires": {
         "boxen": "^1.2.1",
         "chalk": "^2.0.1",
@@ -25818,7 +25818,7 @@
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -25891,7 +25891,7 @@
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+      "integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8="
     },
     "utf8-byte-length": {
       "version": "1.0.4",
@@ -25929,7 +25929,7 @@
     "util.promisify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
-      "integrity": "sha1-RA9xZaRZyaFtwUXrjnLzVocJcDA=",
+      "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
       "requires": {
         "define-properties": "^1.1.2",
         "object.getownpropertydescriptors": "^2.0.3"
@@ -26852,7 +26852,7 @@
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
       "requires": {
         "isexe": "^2.0.0"
       }


### PR DESCRIPTION
https://sparkpost.atlassian.net/browse/SA-95

 A/C:
- Our API Docs accurately reflect the Metrics API features
- Existing support docs accurately reflect the Metrics API features
- The scope is any feature that is shipped to production

Changes made:
- added missing templates list endpoint
- documents that day precision may be used for aggregate requests
- documents that day+ precisions will use UTC regardless of timezone QP
- updated advanced comparator schema query to display URL and a truncated example response
- clarifies the difference in terminology between the Deliverability Add-On product and deliverability as a general term.

Changes not made:
- Uniques are still handled with raw data - we don’t need to explain that uniques are per rollup precision or that 5/15min or week/month are aggregates of 1min/day because it makes no difference to the API consumer.
- We don’t really want people using 15min precision at 48 hours for performance reasons, so I’m going to skip adding more documentation around that.