### PR TITLE
TR-3165 add pulic facing initial_open_include_alt_attribute account option

### DIFF
--- a/content/api/account.apib
+++ b/content/api/account.apib
@@ -38,7 +38,7 @@ Retrieve information regarding your SparkPost account and set account options.
         + transactional_unsub (boolean) - Set to `true` to include `List-Unsubscribe` header for all transactional messages by default
         + transactional_default (boolean) - Set to `true` to send messages as transactional by default
         + initial_open_include_alt_attribute (boolean)
-            Account-level initial open html `alt` tag. `false` by default. To include an alt attribute (alt="") in initial open pixel tracking link tags set the `initial_open_include_alt_attribute` to `true`. Initial open pixel tracking must be enabled.
+            Account-level option for adding an html `alt` attribute to initial open pixels. `false` by default. To include the alt attribute (alt="") in initial open pixel tracking link tags set the `initial_open_include_alt_attribute` to `true`. Initial open pixel tracking must be enabled.
         + initial_open_pixel_tracking (boolean)
             Account-level default for initial open tracking. `true` by default. In order for initial open tracking to be enabled for REST and SMTP by default, `rest_tracking_default` and `smtp_tracking_default` must be `true`.
         + click_tracking (boolean)
@@ -193,7 +193,7 @@ Retrieve information regarding your SparkPost account and set account options.
         + rest_tracking_default (boolean) - Set to `false` to turn off REST API engagement tracking by default
         + transactional_unsub (boolean) - Set to `true` to include `List-Unsubscribe` header for all transactional messages by default
         + transactional_default (boolean) - Set to `true` to send messages as transactional by default
-        + initial_open_include_alt_attribute (boolean) - Set to `true` to include a blank alt attribute in initial open tracking pixel link tags
+        + initial_open_include_alt_attribute (boolean) - Set to `true` to include a blank alt attribute in initial open tracking pixels
         + initial_open_pixel_tracking (boolean) - Set to `false` to exclude the initial open tracking pixel from top of emails
         + click_tracking (boolean)
             Set to `false` to turn off click tracking (overrides smtp_tracking_default and rest_tracking_default)

--- a/content/api/account.apib
+++ b/content/api/account.apib
@@ -37,10 +37,10 @@ Retrieve information regarding your SparkPost account and set account options.
         + rest_tracking_default (boolean) - Account-level default for REST API engagement tracking. `true` by default.
         + transactional_unsub (boolean) - Set to `true` to include `List-Unsubscribe` header for all transactional messages by default
         + transactional_default (boolean) - Set to `true` to send messages as transactional by default
+        + initial_open_include_alt_attribute (boolean)
+            Account-level initial open html `alt` tag. `false` by default. To include an alt attribute (alt="") in initial open pixel tracking link tags set the `initial_open_include_alt_attribute` to `true`. Initial open pixel tracking must be enabled.
         + initial_open_pixel_tracking (boolean)
             Account-level default for initial open tracking. `true` by default. In order for initial open tracking to be enabled for REST and SMTP by default, `rest_tracking_default` and `smtp_tracking_default` must be `true`.
-        + initial_open_type (string)
-            Account-level initial open type. Empty string by default. To include an alt attribute (alt="") in initial open pixel tracking link tags set the initial_open_type to "alt_tag". Initial open pixel tracking must be enabled.
         + click_tracking (boolean)
             Set to `false` to turn off click tracking (overrides smtp_tracking_default and rest_tracking_default)
     + usage (object) - Account quota usage details. Specify 'include=usage' in query string to include usage info. Usage data is not available for Enterprise accounts.
@@ -193,8 +193,8 @@ Retrieve information regarding your SparkPost account and set account options.
         + rest_tracking_default (boolean) - Set to `false` to turn off REST API engagement tracking by default
         + transactional_unsub (boolean) - Set to `true` to include `List-Unsubscribe` header for all transactional messages by default
         + transactional_default (boolean) - Set to `true` to send messages as transactional by default
+        + initial_open_include_alt_attribute (boolean) - Set to `true` to include a blank alt attribute in initial open tracking pixel link tags
         + initial_open_pixel_tracking (boolean) - Set to `false` to exclude the initial open tracking pixel from top of emails
-        + initial_open_type (string) - Set to `"alt_tag"` to include a blank alt attribute in initial open tracking pixel link tags
         + click_tracking (boolean)
             Set to `false` to turn off click tracking (overrides smtp_tracking_default and rest_tracking_default)
 

--- a/content/api/account.apib
+++ b/content/api/account.apib
@@ -39,6 +39,8 @@ Retrieve information regarding your SparkPost account and set account options.
         + transactional_default (boolean) - Set to `true` to send messages as transactional by default
         + initial_open_pixel_tracking (boolean)
             Account-level default for initial open tracking. `true` by default. In order for initial open tracking to be enabled for REST and SMTP by default, `rest_tracking_default` and `smtp_tracking_default` must be `true`.
+        + initial_open_type (string)
+            Account-level initial open type. Empty string by default. To include an alt attribute (alt="") in initial open pixel tracking link tags set the initial_open_type to "alt_tag". Initial open pixel tracking must be enabled.
         + click_tracking (boolean)
             Set to `false` to turn off click tracking (overrides smtp_tracking_default and rest_tracking_default)
     + usage (object) - Account quota usage details. Specify 'include=usage' in query string to include usage info. Usage data is not available for Enterprise accounts.
@@ -192,6 +194,7 @@ Retrieve information regarding your SparkPost account and set account options.
         + transactional_unsub (boolean) - Set to `true` to include `List-Unsubscribe` header for all transactional messages by default
         + transactional_default (boolean) - Set to `true` to send messages as transactional by default
         + initial_open_pixel_tracking (boolean) - Set to `false` to exclude the initial open tracking pixel from top of emails
+        + initial_open_type (string) - Set to `"alt_tag"` to include a blank alt attribute in initial open tracking pixel link tags
         + click_tracking (boolean)
             Set to `false` to turn off click tracking (overrides smtp_tracking_default and rest_tracking_default)
 


### PR DESCRIPTION
**EDIT: (From Chris)**

Adding the initial_open_include_alt_attribute boolean account option to the public docs.

ticket: https://sparkpost.atlassian.net/browse/TR-3165
admin API docs PR: https://github.com/SparkPost/sparkpost-admin-api-documentation/pull/553
accounts api PR: SparkPost/accusers-api#848