### PR TITLE
TR-2860 update TR docs to denote case in/sensitivity

### DIFF
--- a/content/api/recipient-lists.apib
+++ b/content/api/recipient-lists.apib
@@ -14,7 +14,7 @@ The Recipient List API operates on lists as a whole and does not currently suppo
 ### Recipient List Object
 
 + Data Structure: Attributes
-    + id (string) - Unique alphanumeric ID. <br /> Maximum length: 64 bytes
+    + id (string, case sensitive) - Unique alphanumeric ID. <br /> Maximum length: 64 bytes
     + name (string) - Recipient list display name. <br />  Maximum length: 64 bytes
     + description (string) - Description of the recipient list. <br /> Maximum length: 1024 bytes
     + attributes (object) - An object of arbitrary metadata related to this list. This data is not used by the API. It is only for the user.
@@ -123,7 +123,7 @@ The `To` header is only constructed for messages built from email part content. 
 ### Create a Recipient List [POST /v1/recipient-lists{?num_rcpt_errors}]
 
 + Data Structure
-    + id (string) - Unique alphanumeric ID. If an id is not specified, one is generated. <br /> Maximum length: 64 bytes
+    + id (string, case sensitive) - Unique alphanumeric ID. If an id is not specified, one is generated. <br /> Maximum length: 64 bytes
     + name (string) - Recipient list display name. If a name is not specified, it defaults to the same value as id. <br />  Maximum length: 64 bytes
     + description (string) - Description of the recipient list. <br /> Maximum length: 1024 bytes
     + attributes (object) - An object of arbitrary metadata related to this list.
@@ -272,7 +272,7 @@ Retrieve details about a specified recipient list by specifying its id in the UR
 retrieve the recipients contained in a list, the list must be specified and the `show_recipients` parameter must be set to true.
 
 + Parameters
-    + id (required, string, `unique_id_4_graduate_students`)
+    + id (required, string, `unique_id_4_graduate_students`) ... Case sensitive.
     + show_recipients (optional, boolean, `true`) ... If true, return all the recipients contained in the list.
 
 + Request
@@ -393,7 +393,7 @@ If a transmission using the recipient list has a `state` of "submitted" or "gene
 Returns the recipient list's `name` and `id`. If the `recipients` array was updated, it includes the number of accepted and rejected recipients.
 
 + Parameters
-    + id (required, string, `unique_id_4_graduate_students_list`)
+    + id (required, string, `unique_id_4_graduate_students_list`) ... Case sensitive.
     + num_rcpt_errors (optional, number, `3`) ... Maximum number of recipient errors that this call can return, otherwise all validation errors are returned.
 
 + Request (application/json)
@@ -555,7 +555,7 @@ Returns the recipient list's `name` and `id`. If the `recipients` array was upda
 <Banner status="warning">If a transmission contains a recipient list, the recipient list cannot be deleted if the transmission is submitted or generating.</Banner>
 
 + Parameter
-    + id (required, string, `unique_id_4_graduate_students_list`)
+    + id (required, string, `unique_id_4_graduate_students_list`) ... Case sensitive.
 
 + Request
 

--- a/content/api/templates.apib
+++ b/content/api/templates.apib
@@ -18,7 +18,7 @@ If needed, it's also possible to update the published version of a template dire
 ## Template Object
 
 + Data Structure: Attributes
-    + id (string) - Unique alphanumeric ID.
+    + id (string, case sensitive) - Unique alphanumeric ID.
     + name (string) - Display name.
     + description (string) - Description of the template.
     + content (object) - Content that will be used to construct an email. The template language is supported in all content attributes.
@@ -109,7 +109,7 @@ Each error is described in a object with the following attributes:
 Templates are created as drafts.
 
 + Data Structure
-    + id (string) - Unique alphanumeric ID used to reference the template. At a minimum, `id` or `name` is required upon creation. It is auto-generated if not provided. Maximum length - 64 bytes
+    + id (string, case sensitive) - Unique alphanumeric ID used to reference the template. At a minimum, `id` or `name` is required upon creation. It is auto-generated if not provided. Maximum length - 64 bytes
     + name (string) - Editable display name. At a minimum, `id` or `name` is required upon creation. Does not have to be unique. Maximum length - 1024 bytes
     + description (string) - Description of the template. Maximum length - 1024 bytes
     + content (object, required) - Content that will be used to construct an email. The template language is supported in all content attributes. Maximum length - 5 MB
@@ -191,7 +191,7 @@ Templates are created as drafts.
 Use the `draft` query parameter to specify the draft or published version of the template.
 
 + Parameters
-    + id (required, string, `11714265276872`)
+    + id (required, string, `11714265276872`) ... Case sensitive.
     + draft (optional, boolean, `true`) ... If true, returns the draft template. If false, returns the published template.
 
 + Request
@@ -263,7 +263,7 @@ The new content will completely overwrite the existing content.
 
 
 + Parameters
-    + id (required, string, `11714265276872`)
+    + id (required, string, `11714265276872`) ... Case sensitive.
 
 
 + Request Update (application/json)
@@ -349,7 +349,7 @@ The new content will completely overwrite the existing content.
 
 
 + Parameters
-    + id (required, string, `11714265276872`)
+    + id (required, string, `11714265276872`) ... Case sensitive.
     + update_published (optional, boolean, `true`) ... Set to `true` to overwrite the existing published template.
 
 + Request (application/json)
@@ -393,7 +393,7 @@ See [Template Language](/api/template-language/) for more information.
 
 
 + Parameters
-    + id (required, string, `11714265276872`)
+    + id (required, string, `11714265276872`) ... Case sensitive.
     + draft (optional, boolean, `true`) ... If true, previews the draft template. If false, previews the published template.
 
 + Request (application/json)
@@ -437,7 +437,7 @@ Deletes both published and draft versions of a template.
 <Banner status="info">If a transmission uses a template, the template cannot be deleted if the transmission is submitted or generating.</Banner>
 
 + Parameters
-    + id (required, string, `11714265276872`)
+    + id (required, string, `11714265276872`) ... Case sensitive.
 
 + Request
 

--- a/content/api/tracking-domains.apib
+++ b/content/api/tracking-domains.apib
@@ -51,7 +51,7 @@ In order to be associated to a subaccount's sending domain, a tracking domain ha
 ## Tracking Domain Object
 
 + Data Structure
-    + domain (string) - Name of the tracking domain.
+    + domain (string, case insensitive) - Name of the tracking domain.
     + port (number) - The port used when constructing the tracking URL. `80` if secure is `false`, `443` if secure is `true`.
     + secure (boolean) - Whether the tracking URL should use HTTPS. HTTP will be used if `false`.
         + Default: false
@@ -88,7 +88,7 @@ In order to be associated to a subaccount's sending domain, a tracking domain ha
 ### Create a Tracking Domain [POST /v1/tracking-domains]
 
 + Data Structure
-    + domain (string, required) - Name of the tracking domain.
+    + domain (string, case insensitive, required) - Name of the tracking domain.
     + secure (boolean) - Whether the tracking URL should use HTTPS. HTTP will be used if `false`.
         + Default: false
 
@@ -161,7 +161,7 @@ In order to be associated to a subaccount's sending domain, a tracking domain ha
 Initiate a check against the configured redirect for the specified tracking domain. The domain's `status` object is returned on success.
 
 + Parameters
-    + domain (required, string, `example.domain.com`)
+    + domain (required, case insensitive, string, `example.domain.com`)
 
 
 + Request
@@ -210,7 +210,7 @@ Initiate a check against the configured redirect for the specified tracking doma
 Retrieve an existing tracking domain.
 
 + Parameters
-    + domain (required, string, `example.domain.com`)
+    + domain (required, case insensitive, string, `example.domain.com`)
 
 + Request
 
@@ -276,7 +276,7 @@ Setting a new default automatically unsets the current relevant default, if it e
 
 
 + Parameters
-    + domain (required, string, `example.domain.com`)
+    + domain (required, case insensitive, string, `example.domain.com`)
 
 + Request
 
@@ -345,7 +345,7 @@ Setting a new default automatically unsets the current relevant default, if it e
 Delete an existing tracking domain.
 
 + Parameters
-    + domain (required, string, `example.domain.com`)
+    + domain (required, case insensitive, string, `example.domain.com`)
 
 + Request
 

--- a/content/api/transmissions.apib
+++ b/content/api/transmissions.apib
@@ -68,7 +68,7 @@ You can create a transmission in a number of ways. In all cases, you can use the
             + Default: false
         + skip_suppression (boolean) - Whether to ignore customer suppression rules. <span class="label label-warning"><strong>Enterprise</strong></span> only.
             + Default: false.
-        + ip_pool (string) - The ID of a [dedicated IP pool](https://www.sparkpost.com/docs/deliverability/dedicated-ip-pools) to send from. If this field is not provided, the account's default dedicated IP pool is used (if there are IPs assigned to it). <br/><a href="https://www.sparkpost.com/enterprise-email/"><span class="label label-warning"><strong>Enterprise</strong></span></a> accounts, contact your TAM for support details.
+        + ip_pool (string, case insensitive) - The ID of a [dedicated IP pool](https://www.sparkpost.com/docs/deliverability/dedicated-ip-pools) to send from. If this field is not provided, the account's default dedicated IP pool is used (if there are IPs assigned to it). <br/><a href="https://www.sparkpost.com/enterprise-email/"><span class="label label-warning"><strong>Enterprise</strong></span></a> accounts, contact your TAM for support details.
         + inline_css (boolean) - Whether to inline the CSS in `<style>` tags in the `<head>` in the HTML content.  Not performed on AMPHTML Email content.
             + Default: false
         + perform_substitutions (boolean)


### PR DESCRIPTION
### Changes
- Transmissions:
  - `ip_pool` case insensitive
- Templates:
  - `template_id` case sensitive
- Recipient Lists:
  - `id` case sensitive
- Tracking Domains:
  - `domain` case sensitive