### PR TITLE
SAZ-360 adds job_search to industry benchmark industries

### DIFF
--- a/content/api/metrics.apib
+++ b/content/api/metrics.apib
@@ -2596,6 +2596,7 @@ Note: The Inbox Rate Industry Benchmark endpoint is available to the SparkPost <
             + `finance`
             + `food_beverage_service`
             + `govt_education_charity`
+            + `job_search`
             + `media_publishing`
             + `medical`
             + `misc`


### PR DESCRIPTION
Adds `job_search` as an industry benchmark category. I also confirmed that the industry list is up to date and correct when compared to the model in the [Metrics API](https://github.com/SparkPost/metrics-api/blob/main/lib/model/inbox-rate.js#L13).