### PR TITLE
FE-1643 - Add HSTS to developers.sparkpost.com

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,15 @@
   command = "npm run bootstrap && npx netlify-lambda build lambda/ && npm run build"
   functions = "./functions"
 
+[[headers]]
+  # Define which paths this specific [[headers]] block will cover.
+  for = "/*"
+
+  [headers.values]
+    Strict-Transport-Security = '''
+    max-age=31536000;
+    includeSubDomains;'''
+
 # Run `npm run publish` to re-index in algolia
 # [context.production]
 #   publish = "./public"


### PR DESCRIPTION
### What Changed

- Added the HSTS header 
- Added the Max Age of HSTS header for 1 year.  This header tells the user agent only connect to the site and subdomains via HTTPS for the next 1 year. We have had it set to 60 days for about 2 years without encountering issues due to it, so its safe to increase the max age. 
- Added includeSubDomains to the HSTS header, This directive notifies the browser that all subdomains of the current origin should also be upgraded via HSTS. For example, setting includeSubDomains on developers.sparkpost.com will also set it on host1.app-staging.sparkpost.com and host2.developers.sparkpost.com. 

***It is advised to practice extreme care when setting the includeSubDomains flag, as it could disable sites on subdomains that don’t yet have HTTPS enabled.  - but we should be good since we don't have subdomains for developers.sparkpost.com in use. [need to verify this]***