### PR TITLE
TR-3636 Clarify subaccount behavior of DELETE /v1/suppresion-list/{recipient}

### DIFF
--- a/content/api/suppression-list.apib
+++ b/content/api/suppression-list.apib
@@ -228,6 +228,14 @@ If you don't have subaccounts, you do not need to provide the `X-MSYS-SUBACCOUNT
 
 ### Delete a Suppression [DELETE /v1/suppression-list/{recipient}]
 
+
+##### Deleting from subaccounts
+
+If your account has subaccounts, please provide the `X-MSYS-SUBACCOUNT` header when deleting from a specific subaccount suppression list.
+- Omit the header to delete from the primary account suppression list.
+- Use the subaccount's ID to delete from a specific subaccount suppression list.
+
+
 + Data Structure
     + type (enum) - The type of suppression to delete. If not provided, the suppression will be deleted for both transactional and non-transactional.
         + transactional


### PR DESCRIPTION
Ticket link: https://sparkpost.atlassian.net/browse/TR-3636

Clarify subaccount behavior of `DELETE /v1/suppresion-list/{recipient}`, since one customer was confused whether or not it would delete across the main account & subaccount in case the `X-MSYS-SUBACCOUNT` header wasn't provided

<img width="660" alt="image" src="https://user-images.githubusercontent.com/102970234/165100143-d778252d-d1bf-4034-9573-98d1b94d5a54.png">
