### PR TITLE
Improving AB tests warning banners

### DIFF
--- a/content/api/ab-testing.apib
+++ b/content/api/ab-testing.apib
@@ -24,7 +24,7 @@ The `test_mode` defines what happens once the A/B test completes. In `learning` 
 
 In Bayesian mode, when a template reaches the set `confidence_level` it becomes the winner. If a test ends by hitting one of the other conditions and the `confidence_level` has not been reached, the default template will be considered the winner.
 
-<Banner status="warning">A/B Tests only support inline single recipient transmissions currently</Banner>
+<Banner status="warning">A/B Tests only support single recipient transmissions currently</Banner>
 
 ### Versions
 

--- a/content/api/transmissions.apib
+++ b/content/api/transmissions.apib
@@ -378,7 +378,7 @@ The following attribute should be set in the `content` object when sending an A/
 
 When using substitution data with A/B tests, data for all possible templates must be provided.  We recommend that all templates that make up an A/B test should use the same substitution data fields.
 
-<Banner status="warning">A/B Tests only support inline single recipient transmissions currently</Banner>
+<Banner status="warning">A/B Tests only support single recipient transmissions currently</Banner>
 
 + Request
 


### PR DESCRIPTION
These banners got one of our customers confused, since `inline` frequently refers to inline template. Per suggestion of Kieran Cooper, I'm just removing the `inline` word from the banners