### PR TITLE
Fix the 'data-msys-linkname' size limit doc from 63 char to bytes

### DIFF
--- a/content/api/template-language.apib
+++ b/content/api/template-language.apib
@@ -605,7 +605,7 @@ Link names are used to identify links in click events in both webhook payloads a
 <a href="http://www.example.com" data-msys-linkname="banner">Example</a>
 ```
 
-Link names have a maximum length of 63 bytes and are truncated if they exceed the limit. Be wary of multibyte characters since they will be truncated with less than 63 characters.
+Link names are limited to 63 bytes and will be automatically truncated if they exceed this limit. Note that some characters can count as multiple bytes when encoded, so links containing these characters may be truncated at fewer than 63 visible characters.
 
 #### Unsubscribe Links
 

--- a/content/api/template-language.apib
+++ b/content/api/template-language.apib
@@ -605,7 +605,7 @@ Link names are used to identify links in click events in both webhook payloads a
 <a href="http://www.example.com" data-msys-linkname="banner">Example</a>
 ```
 
-Link names have a maximum length of 63 characters and are truncated if they exceed the limit.
+Link names have a maximum length of 63 bytes and are truncated if they exceed the limit. Be wary of multibyte characters since they will be truncated with less than 63 characters.
 
 #### Unsubscribe Links
 


### PR DESCRIPTION
SAS has complained that while using multibyte Japanese and Chinese characters in the `data-msys-linkname` field, it was getting truncated with less than 63 characters. Our documentation pointed out that the size limit for that field was 63 characters and not 63 bytes, but that was not true. The limit was indeed 63 bytes and since Japanese and Chinese characters do occupy more than 1byte each they were getting truncated. This is a documentation fix. 
