### PR TITLE
docs: add Users API reference page

### DIFF
--- a/content/api/table-of-contents.json
+++ b/content/api/table-of-contents.json
@@ -42,6 +42,7 @@
     "pages": [
       "account.apib",
       "subaccounts.apib",
+      "users.apib",
       "data-privacy.apib"
     ]
   },

--- a/content/api/users.apib
+++ b/content/api/users.apib
@@ -6,18 +6,16 @@ description: Programmatically manage the users on your SparkPost account with an
 
 The Users API lets you list, invite, update, and remove the users on your account, and manage each user's subaccount access, using an API key rather than the web app.
 
-<Banner status="warning"><strong>Note</strong>: This API is available only to accounts that have user management via API keys enabled. See <a href="#header-prerequisites">Prerequisites</a> below. Contact <a href="https://www.sparkpost.com/contact-support/">SparkPost support</a> to request access.</Banner>
-
 ### Prerequisites
 
-Two conditions must both be met before an API key can call the Users API:
+To call the Users API, an API key must hold one of two grants, and an **admin** must attach the grant to the key through the web app's [API Keys page](https://app.sparkpost.com/account/api-keys). A grant cannot be attached by another API key. Both are `api_key`-role grants.
 
-1. **User management via API keys must be enabled on your account.** This is enabled only by SparkPost support. Contact support to request access for your account.
-2. **An admin must attach the `Users: Manage` grant to the API key.** The grant can only be added by an **admin** user through the web app's [API Keys page](https://app.sparkpost.com/account/api-keys). It cannot be attached by another API key. Only API keys carry this grant — it is an `api_key`-role grant.
+* **`Users: View`** — read-only access, covering the `GET` endpoints only: [List Users](#header-list-users), [Retrieve a User](#header-retrieve-a-user), [List Pending Invites](#header-list-pending-invites), and [List a User's Subaccounts](#header-list-a-users-subaccounts).
+* **`Users: Manage`** — full management. Every write endpoint (invite, update, delete, and the subaccount-mapping changes) requires this grant.
 
-Requests made with a key that lacks the `Users: Manage` grant, or made on an account where the feature is not enabled, are rejected with `403 Forbidden`.
+Requests made with a key that holds neither grant, or that attempt a write with only `Users: View`, are rejected with `403 Forbidden`.
 
-<Banner status="info">The <code>Users: Manage</code> grant is intentionally narrower than the user management available in the web app. It does <strong>not</strong> cover two-factor authentication, email verification, SCIM provisioning, or password endpoints, and it does not allow direct password-based user creation (see <a href="#header-invite-a-user">Invite a User</a>).</Banner>
+<Banner status="info">These grants are intentionally narrower than the user management available in the web app. They do <strong>not</strong> cover two-factor authentication, email verification, SCIM provisioning, or password endpoints, and they do not allow direct password-based user creation (see <a href="#header-invite-a-user">Invite a User</a>).</Banner>
 
 ### Roles
 

--- a/content/api/users.apib
+++ b/content/api/users.apib
@@ -41,13 +41,13 @@ The following rules are enforced on every Users API request. They protect agains
 
 ### User object
 
-Returned by [List Users](#header-list-users) and [Retrieve a User](#header-retrieve-a-user).
+Returned by [List Users](#header-list-users).
 
 + Data Structure: User
     + name (string) - The user's display name, derived from their first and last name.
     + username (string) - Unique username that identifies the user.
     + email (string) - The user's email address.
-    + access (enum) - The user's primary-account role.
+    + access (enum) - The user's primary-account role. Empty for subaccount-scoped users.
         + `admin`
         + `developer`
         + `reporting`
@@ -58,18 +58,49 @@ Returned by [List Users](#header-list-users) and [Retrieve a User](#header-retri
     + email_verified (boolean) - Whether the user has verified their email address.
     + tfa_enabled (boolean) - Whether the user has two-factor authentication enabled.
     + subaccount_id (number) - The subaccount the user is scoped to, if any.
-    + subaccounts (array) - The subaccounts a subaccount-scoped user has access to, and their access level on each. Present only for subaccount-scoped users; when it is present, the top-level `access` and `subaccount_id` fields are omitted.
+    + subaccounts (array) - The subaccounts a subaccount-scoped user has access to, and their access level on each. Present only for subaccount-scoped users.
+        + (object)
+            + subaccount_id (number) - The subaccount ID.
+            + access_level (enum) - The user's access level on the subaccount.
+                + `subaccount_reporting`
+                + `subaccount_developer`
+            + subaccount_name (string) - The subaccount's display name.
+    + options (object) - User-level options, present only when set.
+
+### Retrieved user object
+
+Returned by [Retrieve a User](#header-retrieve-a-user). This is a richer shape than the [User object](#header-user-object) returned by List Users: it has `first_name` and `last_name` in place of `name`, uses `access_level` for the primary-account role, and adds `created`, `updated`, and an always-present `subaccounts` array.
+
++ Data Structure: RetrievedUser
+    + username (string) - Unique username that identifies the user.
+    + first_name (string) - The user's first name.
+    + last_name (string) - The user's last name.
+    + email (string) - The user's email address.
+    + access_level (enum) - The user's primary-account role. Omitted for subaccount-scoped users.
+        + `admin`
+        + `developer`
+        + `reporting`
+        + `templates`
+        + `custom`
+    + access_policies (array) - The policies granted to the user when `access_level` is `custom`.
+    + subaccount_id (number) - The subaccount the user is scoped to, if any. Omitted when `subaccounts` is non-empty.
+    + is_sso (boolean) - Whether the user signs in via single sign-on.
+    + email_verified (boolean) - Whether the user has verified their email address.
+    + tfa_enabled (boolean) - Whether the user has two-factor authentication enabled.
+    + options (object) - User-level options, present only when set.
+    + created (string) - ISO 8601 timestamp of when the user was created.
+    + updated (string) - ISO 8601 timestamp of when the user was last updated.
+    + subaccounts (array) - The subaccounts the user has access to, and their access level on each. Always present; an empty array for a user with no subaccount mappings. When it is non-empty, the top-level `access_level` and `subaccount_id` fields are omitted.
         + (object)
             + subaccount_id (number) - The subaccount ID.
             + subaccount_name (string) - The subaccount's display name.
             + access_level (enum) - The user's access level on the subaccount.
                 + `subaccount_reporting`
                 + `subaccount_developer`
-            + status (enum) - The subaccount's status. Returned only by [Retrieve a User](#header-retrieve-a-user).
+            + status (enum) - The subaccount's status.
                 + active
                 + suspended
                 + terminated
-    + options (object) - User-level options, present only when set.
 
 ### Invite object
 
@@ -142,9 +173,7 @@ Returns the users on your account.
 
 ### Retrieve a User [GET /v1/users/{username}]
 
-Returns a single user by username.
-
-For a subaccount-scoped user, the response embeds the `subaccounts` array in place of the top-level `access` and `subaccount_id` fields.
+Returns a single user by username. The response uses the [Retrieved user object](#header-retrieved-user-object) shape, which differs from the [User object](#header-user-object) returned by List Users.
 
 + Parameters
     + username (required, string, `grace`) - The username of the user to retrieve.
@@ -160,13 +189,17 @@ For a subaccount-scoped user, the response embeds the `subaccounts` array in pla
 
         {
             "results": {
-                "name": "Grace Hopper",
                 "username": "grace",
+                "first_name": "Grace",
+                "last_name": "Hopper",
                 "email": "grace@example.com",
-                "access": "reporting",
+                "access_level": "reporting",
                 "is_sso": false,
                 "email_verified": true,
-                "tfa_enabled": true
+                "tfa_enabled": true,
+                "created": "2015-01-11T08:00:00.000Z",
+                "updated": "2018-04-11T08:00:00.000Z",
+                "subaccounts": []
             }
         }
 
@@ -176,12 +209,15 @@ For a subaccount-scoped user, the response embeds the `subaccounts` array in pla
 
         {
             "results": {
-                "name": "Joe Mechanic",
                 "username": "joe",
+                "first_name": "Joe",
+                "last_name": "Mechanic",
                 "email": "joe@example.com",
                 "is_sso": false,
                 "email_verified": true,
                 "tfa_enabled": false,
+                "created": "2015-01-11T08:00:00.000Z",
+                "updated": "2018-04-11T08:00:00.000Z",
                 "subaccounts": [
                     {
                         "subaccount_id": 123,

--- a/content/api/users.apib
+++ b/content/api/users.apib
@@ -62,7 +62,7 @@ Every user is scoped either to the account or to one or more subaccounts. An acc
         + `custom`
     + `access_policies` (array[string]) - The [access policies](#header-access-policies) granted to the user. Only present when `access_level` is `custom`.
     + is_sso (boolean) - Whether the user signs in via single sign-on.
-    + email_verified (boolean) - Whether the user has verified their email address.
+    + email_verified (boolean) - Whether the user has verified their email address. Always `true` for a single sign-on user, whose identity provider vouches for the address.
     + tfa_enabled (boolean) - Whether the user has two-factor authentication enabled.
     + last_login (string, nullable) - ISO 8601 timestamp of the user's last sign-in, or `null` if they have never signed in.
     + subaccounts (array[object]) - The subaccounts the user can reach, and their role on each. See [Subaccount access object](#header-subaccount-access-object). Returned by [Retrieve a User](#header-retrieve-a-user) only, and empty for an account-scoped user.

--- a/content/api/users.apib
+++ b/content/api/users.apib
@@ -51,8 +51,8 @@ Every user is scoped either to the account or to one or more subaccounts. An acc
 
 + Data Structure: Attributes
     + username (string) - Unique username that identifies the user.
-    + first_name (string, nullable) - The user's first name.
-    + last_name (string, nullable) - The user's last name.
+    + first_name (string) - The user's first name. Only present when the user has set it.
+    + last_name (string) - The user's last name. Only present when the user has set it.
     + email (string) - The user's email address.
     + access_level (enum) - The user's [role](#header-roles) on the account. Absent for subaccount-scoped users.
         + `admin`

--- a/content/api/users.apib
+++ b/content/api/users.apib
@@ -144,7 +144,7 @@ Returns the users on your account.
 
 Returns a single user by username.
 
-For a subaccount-scoped user, the response embeds a `subaccounts` array describing the subaccounts the user can access and their access level on each. When `subaccounts` is present, the top-level `access` and `subaccount_id` fields are omitted.
+For a subaccount-scoped user, the response embeds the `subaccounts` array in place of the top-level `access` and `subaccount_id` fields.
 
 + Parameters
     + username (required, string, `grace`) - The username of the user to retrieve.

--- a/content/api/users.apib
+++ b/content/api/users.apib
@@ -218,7 +218,7 @@ The response contains the invite `id`, which you use to [list](#header-list-pend
         {
             "errors": [
                 {
-                    "message": "API keys cannot invite an admin-level user."
+                    "message": "An admin-level user cannot be invited through the API."
                 }
             ]
         }
@@ -457,7 +457,7 @@ Returns one user by username, in the [User object](#header-user-object) shape.
         {
             "errors": [
                 {
-                    "message": "API keys may only modify access_level and access_policies."
+                    "message": "Only access_level and access_policies can be modified through the API."
                 }
             ]
         }

--- a/content/api/users.apib
+++ b/content/api/users.apib
@@ -1,0 +1,425 @@
+FORMAT: 1A
+title: Users API
+description: Programmatically manage the users on your SparkPost account with an API key.
+
+# Group Users
+
+The Users API lets you list, invite, update, and remove the users on your account, and manage each user's subaccount access, using an API key rather than the web app.
+
+<Banner status="warning"><strong>Note</strong>: This API is available only to accounts that have user management via API keys enabled. See <a href="#header-prerequisites">Prerequisites</a> below. Contact <a href="https://www.sparkpost.com/contact-support/">SparkPost support</a> to request access.</Banner>
+
+### Prerequisites
+
+Two conditions must both be met before an API key can call the Users API:
+
+1. **The account option `allow_user_management_via_api` must be enabled.** This option is enabled only by SparkPost support; it cannot be toggled through the API or the web app. Contact support to request it for your account.
+2. **An admin must attach the `Users: Manage` grant to the API key.** The grant can only be added by an **admin** user through the web app's [API Keys page](https://app.sparkpost.com/account/api-keys). It cannot be attached by another API key. Only API keys carry this grant — it is an `api_key`-role grant.
+
+Requests made with a key that lacks the `Users: Manage` grant, or made on an account where the option is not enabled, are rejected with `403 Forbidden`.
+
+<Banner status="info">The <code>Users: Manage</code> grant is intentionally narrower than the user management available in the web app. It does <strong>not</strong> cover two-factor authentication, email verification, SCIM provisioning, or password endpoints, and it does not allow direct password-based user creation (see <a href="#header-invite-a-user">Invite a User</a>).</Banner>
+
+### Roles
+
+When you invite or update a user you assign a **role** through the `access_level` field. The primary-account roles are:
+
+| Role | Description |
+|-------------|-------------------------------------------------------------|
+| `admin` | Full access to the account, including user and billing management. |
+| `developer` | Access to sending and configuration APIs, without account administration. |
+| `reporting` | Read-only access to reporting and analytics. |
+| `templates` | Access limited to managing templates. |
+| `custom` | A role whose permissions are defined by the `access_policies` you supply. |
+
+Subaccount access levels (used only in the `subaccounts` array and in the subaccount-mapping endpoints) are `subaccount_reporting` and `subaccount_developer`.
+
+### Constraints
+
+The following rules are enforced on every Users API request. They protect against privilege escalation and account lockout:
+
+* **Role ceiling.** You can never create or invite a user, or raise a user to a role, more privileged than the role of the user who owns the API key. An admin-owned key can assign up to `admin`; a key owned by a less-privileged user is bounded by that user's role.
+* **Last admin protection.** The last `admin` on an account cannot be deleted or demoted through the API. Such a request is rejected with `400`.
+* **Restricted fields on update.** `password`, `tfa_enabled`, `is_sso`, and `email` cannot be changed through the API key. Sending any of `password`, `tfa_enabled`, or `is_sso` on an update is rejected with `403 Forbidden`; `email` is silently ignored.
+* **Key revocation on owner deletion.** If the admin user who owns a key holding the `Users: Manage` grant is deleted, that key is revoked rather than reassigned to another user.
+
+### User object
+
+Returned by [List Users](#header-list-users).
+
++ Data Structure: User
+    + name (string) - The user's display name, derived from their first and last name.
+    + username (string) - Unique username that identifies the user.
+    + email (string) - The user's email address.
+    + access (enum) - The user's primary-account role.
+        + `admin`
+        + `developer`
+        + `reporting`
+        + `templates`
+        + `custom`
+    + access_policies (array) - The policies granted to the user when `access` is `custom`.
+    + is_sso (boolean) - Whether the user signs in via single sign-on.
+    + email_verified (boolean) - Whether the user has verified their email address.
+    + tfa_enabled (boolean) - Whether the user has two-factor authentication enabled.
+    + subaccount_id (number) - The subaccount the user is scoped to, if any.
+    + auth_migrated (boolean) - Internal flag indicating the user's authentication has been migrated.
+    + options (object) - User-level options, present only when set.
+    + link (object) - A link to the individual user resource.
+        + href (string)
+        + rel (string)
+
+### Invite object
+
+Returned by [List Pending Invites](#header-list-pending-invites).
+
++ Data Structure: Invite
+    + id (string) - Unique ID for the pending invite. Use it to revoke the invite.
+    + email (string) - The email address the invite was sent to.
+    + from (string) - The email address of the user who created the invite.
+
+### List Users [GET /v1/users]
+
+Returns the users on your account. Superuser accounts are never included, and users with hidden roles are omitted.
+
+The user identified by the API key's owner determines which users are visible; the key owner must be a user on the account.
+
++ Request
+
+    + Headers
+
+            Authorization: 14ac5499cfdd2bb2859e4476d2e5b1d2bad079bf
+            Accept: application/json
+
++ Response 200 (application/json)
+
+        {
+            "results": [
+                {
+                    "name": "Ada Lovelace",
+                    "username": "ada",
+                    "email": "ada@example.com",
+                    "access": "admin",
+                    "is_sso": false,
+                    "email_verified": true,
+                    "tfa_enabled": false,
+                    "auth_migrated": false,
+                    "link": {
+                        "href": "https://api.sparkpost.com/api/v1/users/ada",
+                        "rel": "urn:msys:user"
+                    }
+                },
+                {
+                    "name": "Grace Hopper",
+                    "username": "grace",
+                    "email": "grace@example.com",
+                    "access": "reporting",
+                    "is_sso": false,
+                    "email_verified": true,
+                    "tfa_enabled": true,
+                    "auth_migrated": false,
+                    "link": {
+                        "href": "https://api.sparkpost.com/api/v1/users/grace",
+                        "rel": "urn:msys:user"
+                    }
+                }
+            ]
+        }
+
++ Response 403 (application/json)
+
+        {
+            "errors": [
+                {
+                    "message": "Forbidden"
+                }
+            ]
+        }
+
+### Invite a User [POST /v1/users/invite]
+
+There is no direct, password-based user creation through the API — users are created by **invitation** only. This endpoint creates an invitation and emails the invitee a registration link; the invitee completes registration through that link and sets their own password. The invited user's role is set by `access_level` and is bounded by the [role ceiling](#header-constraints).
+
+Provide `access_level` for a primary-account user, or `subaccounts` to invite a subaccount-scoped user. When `subaccounts` is supplied, a top-level `access_level` is not required.
+
+The response contains the invite `token`.
+
+<Banner status="danger"><strong>Treat the invite <code>token</code> as a credential.</strong> Anyone who holds the token can complete registration as the invited user. Invited users normally complete registration through the emailed link, so you do not need to handle the token yourself; if you do capture it, store and transmit it as securely as you would a password, and never log or share it.</Banner>
+
++ Data Structure
+    + email (string, required) - Email address of the person to invite. Max length: 512 characters.
+    + access_level (enum) - The primary-account role to assign. Required unless `subaccounts` is supplied.
+        + `admin`
+        + `developer`
+        + `reporting`
+        + `templates`
+        + `custom`
+    + access_policies (array) - The policies to grant. Only valid when `access_level` is `custom`.
+    + subaccounts (array) - Invite the user with access to one or more subaccounts instead of the primary account. Between 1 and 25 entries.
+        + (object)
+            + subaccount_id (number, required) - The subaccount ID.
+            + access_level (enum, required) - The subaccount access level.
+                + `subaccount_reporting`
+                + `subaccount_developer`
+
++ Request (application/json)
+
+    + Headers
+
+            Authorization: 14ac5499cfdd2bb2859e4476d2e5b1d2bad079bf
+
+    + Body
+
+            {
+                "email": "newuser@example.com",
+                "access_level": "reporting"
+            }
+
++ Response 200 (application/json)
+
+        {
+            "results": {
+                "id": "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
+                "token": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"
+            }
+        }
+
++ Response 400 (application/json)
+
+        {
+            "errors": [
+                {
+                    "message": "email is a required parameter",
+                    "param": "email",
+                    "value": null
+                }
+            ]
+        }
+
++ Response 403 (application/json)
+
+        {
+            "errors": [
+                {
+                    "message": "Forbidden"
+                }
+            ]
+        }
+
+### List Pending Invites [GET /v1/users/pending-invites/all]
+
+Returns the invitations on your account that have not yet been accepted.
+
++ Request
+
+    + Headers
+
+            Authorization: 14ac5499cfdd2bb2859e4476d2e5b1d2bad079bf
+            Accept: application/json
+
++ Response 200 (application/json)
+
+        {
+            "results": [
+                {
+                    "id": "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
+                    "email": "newuser@example.com",
+                    "from": "ada@example.com"
+                }
+            ]
+        }
+
+### Revoke a Pending Invite [DELETE /v1/users/pending-invites/{id}]
+
+Revokes a pending invitation so its registration link can no longer be used.
+
++ Parameters
+    + id (required, string, `3f2504e0-4f89-41d3-9a0c-0305e82c3301`) - The invite ID from [List Pending Invites](#header-list-pending-invites).
+
++ Request
+
+    + Headers
+
+            Authorization: 14ac5499cfdd2bb2859e4476d2e5b1d2bad079bf
+
++ Response 204
+
++ Response 404 (application/json)
+
+        {
+            "errors": [
+                {
+                    "message": "User invite ID does not exist"
+                }
+            ]
+        }
+
+### Update a User [PUT /v1/users/{username}]
+
+Updates an existing user. You may change `first_name`, `last_name`, `access_level` (and, for a `custom` role, `access_policies`), and `options`.
+
+<Banner status="warning"><strong>The following fields cannot be changed through an API key</strong>: <code>password</code>, <code>tfa_enabled</code>, <code>is_sso</code>, and <code>email</code>. Including <code>password</code>, <code>tfa_enabled</code>, or <code>is_sso</code> in the request is rejected with <code>403 Forbidden</code>; <code>email</code> is ignored.</Banner>
+
+Changing `access_level` is subject to the [role ceiling](#header-constraints), and demoting the account's last `admin` is rejected with `400`.
+
++ Data Structure
+    + first_name (string) - The user's first name.
+    + last_name (string) - The user's last name.
+    + access_level (enum) - The primary-account role to assign.
+        + `admin`
+        + `developer`
+        + `reporting`
+        + `templates`
+        + `custom`
+    + access_policies (array) - The policies to grant. Only valid when `access_level` is `custom`.
+    + options (object) - User-level options.
+
++ Parameters
+    + username (required, string, `grace`) - The username of the user to update.
+
++ Request (application/json)
+
+    + Headers
+
+            Authorization: 14ac5499cfdd2bb2859e4476d2e5b1d2bad079bf
+
+    + Body
+
+            {
+                "first_name": "Grace",
+                "last_name": "Hopper",
+                "access_level": "developer"
+            }
+
++ Response 200 (application/json)
+
+        {
+            "results": {
+                "message": "Successfully modified user grace"
+            }
+        }
+
++ Response 400 (application/json)
+
+        {
+            "errors": [
+                {
+                    "message": "Cannot change the access level of the last admin user on the account."
+                }
+            ]
+        }
+
++ Response 403 (application/json)
+
+        {
+            "errors": [
+                {
+                    "message": "Forbidden"
+                }
+            ]
+        }
+
+### Delete a User [DELETE /v1/users/{username}]
+
+Deletes a user from your account.
+
+You cannot delete the user who owns the API key you are calling with, a user that belongs to a different account, or the account's last `admin`.
+
++ Parameters
+    + username (required, string, `grace`) - The username of the user to delete.
+
++ Request
+
+    + Headers
+
+            Authorization: 14ac5499cfdd2bb2859e4476d2e5b1d2bad079bf
+
++ Response 204
+
++ Response 400 (application/json)
+
+        {
+            "errors": [
+                {
+                    "message": "Cannot delete the last admin user on the account."
+                }
+            ]
+        }
+
++ Response 403 (application/json)
+
+        {
+            "errors": [
+                {
+                    "message": "Forbidden"
+                }
+            ]
+        }
+
++ Response 404 (application/json)
+
+        {
+            "errors": [
+                {
+                    "message": "User does not exist"
+                }
+            ]
+        }
+
+### Add a Subaccount Mapping [POST /v1/users/{username}/subaccounts]
+
+Grants a user access to a subaccount at the given access level. If the user already has access to the subaccount, the access level is updated.
+
++ Data Structure
+    + subaccount_id (number, required) - The subaccount to grant access to.
+    + access_level (enum, required) - The access level to grant on the subaccount.
+        + `subaccount_reporting`
+        + `subaccount_developer`
+
++ Parameters
+    + username (required, string, `grace`) - The username of the user.
+
++ Request (application/json)
+
+    + Headers
+
+            Authorization: 14ac5499cfdd2bb2859e4476d2e5b1d2bad079bf
+
+    + Body
+
+            {
+                "subaccount_id": 123,
+                "access_level": "subaccount_reporting"
+            }
+
++ Response 200 (application/json)
+
+        {
+            "results": {
+                "message": "Subaccount access granted"
+            }
+        }
+
++ Response 400 (application/json)
+
+        {
+            "errors": [
+                {
+                    "message": "access_level must be one of: subaccount_reporting, subaccount_developer"
+                }
+            ]
+        }
+
+### Remove a Subaccount Mapping [DELETE /v1/users/{username}/subaccounts/{subaccountId}]
+
+Removes a user's access to a subaccount.
+
++ Parameters
+    + username (required, string, `grace`) - The username of the user.
+    + subaccountId (required, number, `123`) - The subaccount to remove access to.
+
++ Request
+
+    + Headers
+
+            Authorization: 14ac5499cfdd2bb2859e4476d2e5b1d2bad079bf
+
++ Response 204

--- a/content/api/users.apib
+++ b/content/api/users.apib
@@ -12,10 +12,10 @@ The Users API lets you list, invite, update, and remove the users on your accoun
 
 Two conditions must both be met before an API key can call the Users API:
 
-1. **The account option `allow_user_management_via_api` must be enabled.** This option is enabled only by SparkPost support; it cannot be toggled through the API or the web app. Contact support to request it for your account.
+1. **User management via API keys must be enabled on your account.** This is enabled only by SparkPost support. Contact support to request access for your account.
 2. **An admin must attach the `Users: Manage` grant to the API key.** The grant can only be added by an **admin** user through the web app's [API Keys page](https://app.sparkpost.com/account/api-keys). It cannot be attached by another API key. Only API keys carry this grant — it is an `api_key`-role grant.
 
-Requests made with a key that lacks the `Users: Manage` grant, or made on an account where the option is not enabled, are rejected with `403 Forbidden`.
+Requests made with a key that lacks the `Users: Manage` grant, or made on an account where the feature is not enabled, are rejected with `403 Forbidden`.
 
 <Banner status="info">The <code>Users: Manage</code> grant is intentionally narrower than the user management available in the web app. It does <strong>not</strong> cover two-factor authentication, email verification, SCIM provisioning, or password endpoints, and it does not allow direct password-based user creation (see <a href="#header-invite-a-user">Invite a User</a>).</Banner>
 
@@ -39,12 +39,11 @@ The following rules are enforced on every Users API request. They protect agains
 
 * **Role ceiling.** You can never create or invite a user, or raise a user to a role, more privileged than the role of the user who owns the API key. An admin-owned key can assign up to `admin`; a key owned by a less-privileged user is bounded by that user's role.
 * **Last admin protection.** The last `admin` on an account cannot be deleted or demoted through the API. Such a request is rejected with `400`.
-* **Restricted fields on update.** `password`, `tfa_enabled`, `is_sso`, and `email` cannot be changed through the API key. Sending any of `password`, `tfa_enabled`, or `is_sso` on an update is rejected with `403 Forbidden`; `email` is silently ignored.
 * **Key revocation on owner deletion.** If the admin user who owns a key holding the `Users: Manage` grant is deleted, that key is revoked rather than reassigned to another user.
 
 ### User object
 
-Returned by [List Users](#header-list-users).
+Returned by [List Users](#header-list-users) and [Retrieve a User](#header-retrieve-a-user).
 
 + Data Structure: User
     + name (string) - The user's display name, derived from their first and last name.
@@ -61,11 +60,7 @@ Returned by [List Users](#header-list-users).
     + email_verified (boolean) - Whether the user has verified their email address.
     + tfa_enabled (boolean) - Whether the user has two-factor authentication enabled.
     + subaccount_id (number) - The subaccount the user is scoped to, if any.
-    + auth_migrated (boolean) - Internal flag indicating the user's authentication has been migrated.
     + options (object) - User-level options, present only when set.
-    + link (object) - A link to the individual user resource.
-        + href (string)
-        + rel (string)
 
 ### Invite object
 
@@ -75,12 +70,24 @@ Returned by [List Pending Invites](#header-list-pending-invites).
     + id (string) - Unique ID for the pending invite. Use it to revoke the invite.
     + email (string) - The email address the invite was sent to.
     + from (string) - The email address of the user who created the invite.
+    + access_level (enum) - The role the invited user will be assigned when they register.
+        + `admin`
+        + `developer`
+        + `reporting`
+        + `templates`
+        + `custom`
+    + expires (number) - Unix timestamp, in epoch seconds, at which the invitation expires.
+
+### Invite lifecycle
+
+* **Invitations expire after 3 days.** Once an invitation expires, its registration link no longer works.
+* **Expired invitations are removed automatically.** They stop appearing in [List Pending Invites](#header-list-pending-invites) once they expire; you do not need to clean them up.
+* **There is no resend.** To give someone another chance to register, [invite the same email address again](#header-invite-a-user). This creates a new, independent invitation with its own token and expiry; the earlier invitation keeps working until it expires or you [revoke it](#header-revoke-a-pending-invite).
+* **Invite creation is rate limited.** If you create invitations too quickly, requests are rejected with `429 Too Many Requests`. Wait before retrying.
 
 ### List Users [GET /v1/users]
 
-Returns the users on your account. Superuser accounts are never included, and users with hidden roles are omitted.
-
-The user identified by the API key's owner determines which users are visible; the key owner must be a user on the account.
+Returns the users on your account.
 
 + Request
 
@@ -100,12 +107,7 @@ The user identified by the API key's owner determines which users are visible; t
                     "access": "admin",
                     "is_sso": false,
                     "email_verified": true,
-                    "tfa_enabled": false,
-                    "auth_migrated": false,
-                    "link": {
-                        "href": "https://api.sparkpost.com/api/v1/users/ada",
-                        "rel": "urn:msys:user"
-                    }
+                    "tfa_enabled": false
                 },
                 {
                     "name": "Grace Hopper",
@@ -114,12 +116,7 @@ The user identified by the API key's owner determines which users are visible; t
                     "access": "reporting",
                     "is_sso": false,
                     "email_verified": true,
-                    "tfa_enabled": true,
-                    "auth_migrated": false,
-                    "link": {
-                        "href": "https://api.sparkpost.com/api/v1/users/grace",
-                        "rel": "urn:msys:user"
-                    }
+                    "tfa_enabled": true
                 }
             ]
         }
@@ -130,6 +127,44 @@ The user identified by the API key's owner determines which users are visible; t
             "errors": [
                 {
                     "message": "Forbidden"
+                }
+            ]
+        }
+
+### Retrieve a User [GET /v1/users/{username}]
+
+Returns a single user by username.
+
++ Parameters
+    + username (required, string, `grace`) - The username of the user to retrieve.
+
++ Request
+
+    + Headers
+
+            Authorization: 14ac5499cfdd2bb2859e4476d2e5b1d2bad079bf
+            Accept: application/json
+
++ Response 200 (application/json)
+
+        {
+            "results": {
+                "name": "Grace Hopper",
+                "username": "grace",
+                "email": "grace@example.com",
+                "access": "reporting",
+                "is_sso": false,
+                "email_verified": true,
+                "tfa_enabled": true
+            }
+        }
+
++ Response 404 (application/json)
+
+        {
+            "errors": [
+                {
+                    "message": "User does not exist"
                 }
             ]
         }
@@ -204,9 +239,19 @@ The response contains the invite `token`.
             ]
         }
 
-### List Pending Invites [GET /v1/users/pending-invites/all]
++ Response 429 (application/json)
 
-Returns the invitations on your account that have not yet been accepted.
+        {
+            "errors": [
+                {
+                    "message": "Too many invite requests. Please try again later."
+                }
+            ]
+        }
+
+### List Pending Invites [GET /v1/users/pending-invites]
+
+Returns the invitations on your account that have not yet been accepted. Expired invitations are not included.
 
 + Request
 
@@ -222,7 +267,9 @@ Returns the invitations on your account that have not yet been accepted.
                 {
                     "id": "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
                     "email": "newuser@example.com",
-                    "from": "ada@example.com"
+                    "from": "ada@example.com",
+                    "access_level": "reporting",
+                    "expires": 1720656000
                 }
             ]
         }
@@ -254,9 +301,7 @@ Revokes a pending invitation so its registration link can no longer be used.
 
 ### Update a User [PUT /v1/users/{username}]
 
-Updates an existing user. You may change `first_name`, `last_name`, `access_level` (and, for a `custom` role, `access_policies`), and `options`.
-
-<Banner status="warning"><strong>The following fields cannot be changed through an API key</strong>: <code>password</code>, <code>tfa_enabled</code>, <code>is_sso</code>, and <code>email</code>. Including <code>password</code>, <code>tfa_enabled</code>, or <code>is_sso</code> in the request is rejected with <code>403 Forbidden</code>; <code>email</code> is ignored.</Banner>
+Updates an existing user. Through this endpoint you can change the following fields: `first_name`, `last_name`, `access_level` (and, when `access_level` is `custom`, `access_policies`), and `options`.
 
 Changing `access_level` is subject to the [role ceiling](#header-constraints), and demoting the account's last `admin` is rejected with `400`.
 
@@ -360,6 +405,33 @@ You cannot delete the user who owns the API key you are calling with, a user tha
             "errors": [
                 {
                     "message": "User does not exist"
+                }
+            ]
+        }
+
+### List a User's Subaccounts [GET /v1/users/{username}/subaccounts]
+
+Returns the subaccounts a user has been granted access to, along with their access level on each.
+
++ Parameters
+    + username (required, string, `grace`) - The username of the user.
+
++ Request
+
+    + Headers
+
+            Authorization: 14ac5499cfdd2bb2859e4476d2e5b1d2bad079bf
+            Accept: application/json
+
++ Response 200 (application/json)
+
+        {
+            "results": [
+                {
+                    "subaccount_id": 123,
+                    "subaccount_name": "Joe's Garage",
+                    "access_level": "subaccount_reporting",
+                    "status": "active"
                 }
             ]
         }

--- a/content/api/users.apib
+++ b/content/api/users.apib
@@ -1,25 +1,26 @@
 FORMAT: 1A
 title: Users API
-description: Programmatically manage the users on your SparkPost account with an API key.
+description: Manage the users on your SparkPost account.
+label: New
 
 # Group Users
 
-Use the Users API to manage your account's users from code instead of the web app. You can list users, invite new ones, change roles, remove users, and manage each user's subaccount access.
+Use the Users API to manage the users on your account: list them, invite new ones, change their roles, and remove them.
 
-### Prerequisites
+### Grants
 
-Every call needs an API key holding one of two grants. Only an admin can attach either grant, and only from the web app's [API Keys page](https://app.sparkpost.com/account/api-keys). No API key can attach a grant, not even a key that already holds one.
+Every request needs an API key with one of two grants:
 
-* **`Users: View`** gives read-only access to the three `GET` endpoints: [List Users](#header-list-users), [Retrieve a User](#header-retrieve-a-user), and [List Pending Invites](#header-list-pending-invites).
-* **`Users: Manage`** covers the same reads plus every write: invite, update, delete, and the subaccount-mapping changes.
+* `Users: View` allows the three `GET` endpoints: [List Users](#header-list-users), [Retrieve a User](#header-retrieve-a-user), and [List Pending Invites](#header-list-pending-invites).
+* `Users: Manage` allows those reads plus every write: invite, update, and delete.
 
-A key holding neither grant gets `403`, and so does a write attempted with only `Users: View`.
+Only an admin can add these grants, and only from the web app's [API Keys page](https://app.sparkpost.com/account/api-keys).
 
-<Banner status="info">These grants cover less than the web app's user management. They do not reach two-factor authentication, email verification, SCIM provisioning, or password endpoints, and they cannot create a user directly with a password. New users join by <a href="#header-invite-a-user">invitation</a>.</Banner>
+A key with neither grant returns `403`, as does a write attempted with only `Users: View`.
 
 ### Roles
 
-Inviting or updating a user assigns a role through the `access_level` field. The primary-account roles are:
+The `access_level` field sets a user's role when you invite or update them. The primary-account roles are:
 
 | Role | Description |
 |-------------|-------------------------------------------------------------|
@@ -29,22 +30,35 @@ Inviting or updating a user assigns a role through the `access_level` field. The
 | `templates` | Access limited to managing templates. |
 | `custom` | A role whose permissions are defined by the `access_policies` you supply. |
 
-Subaccount-scoped users take one of two access levels instead, `subaccount_reporting` or `subaccount_developer`. These appear only in the `subaccounts` array and in the subaccount-mapping endpoints.
+Subaccount-scoped users take `subaccount_reporting` or `subaccount_developer` instead.
 
-### Constraints
+### Access policies
 
-These rules apply to every Users API request. They stop a key from escalating its own privileges or locking an account out of its own administration.
+A user with the `custom` role gets exactly the policies you list in `access_policies`, and nothing else. Supply them as an array of policy names. The field is only valid when `access_level` is `custom`.
 
-* **No admin through the API.** An API key never assigns the `admin` role, not even a key owned by an admin. Inviting a user as `admin` returns `403`, and so does promoting one. Create admins in the web app.
-* **Role ceiling.** Below admin, a key can only grant a role at or under the role held by the user who owns it. A key owned by a `reporting` user invites `reporting` users and nothing higher.
-* **Last admin protection.** The API refuses to delete or demote the last `admin` on an account, returning `400`.
-* **Self-deletion.** A key cannot delete its own owner.
+| Policy | Grants |
+|--------|--------|
+| `alerts/full` | View and manage alerts. |
+| `api_keys/full` | Manage API keys. |
+| `ab_testing/full` | View and manage A/B tests of email templates. |
+| `domains/full` | View and manage sending, bounce, and tracking domains. |
+| `events/read` | View and search message events. |
+| `ip_pools/full` | View and manage IP pools. |
+| `recipient_lists/full` | View and manage recipient lists. |
+| `recipient_validation/full` | Validate email addresses and view recent validations. |
+| `seeds/full` | View seeding activity and manage seed list settings. |
+| `signals_analytics/full` | View and manage analytics metrics, dashboards, and reports, including health score, spam traps, engagement recency, and blocklist incidents. |
+| `subaccounts/full` | Manage subaccounts. |
+| `suppressions/full` | View and manage suppressions. |
+| `templates/full` | View, manage, and preview email templates and snippets. |
+| `users/full` | View and manage users. |
+| `webhooks/full` | View, manage, and test webhooks. |
 
 ### User object
 
 Returned by [List Users](#header-list-users).
 
-+ Data Structure: User
++ Data Structure: Attributes
     + name (string) - The user's display name, derived from their first and last name.
     + username (string) - Unique username that identifies the user.
     + email (string) - The user's email address.
@@ -54,26 +68,20 @@ Returned by [List Users](#header-list-users).
         + `reporting`
         + `templates`
         + `custom`
-    + access_policies (array) - The policies granted to the user when `access` is `custom`.
+    + `access_policies` (array[string]) - The [access policies](#header-access-policies) granted to the user when `access` is `custom`.
     + is_sso (boolean) - Whether the user signs in via single sign-on.
     + email_verified (boolean) - Whether the user has verified their email address.
     + tfa_enabled (boolean) - Whether the user has two-factor authentication enabled.
     + last_login (string, nullable) - ISO 8601 timestamp of the user's last sign-in, or `null` if they have never signed in.
     + subaccount_id (number) - The subaccount the user is scoped to, if any.
-    + subaccounts (array) - The subaccounts a subaccount-scoped user has access to, and their access level on each. Present only for subaccount-scoped users.
-        + (object)
-            + subaccount_id (number) - The subaccount ID.
-            + access_level (enum) - The user's access level on the subaccount.
-                + `subaccount_reporting`
-                + `subaccount_developer`
-            + subaccount_name (string) - The subaccount's display name.
+    + subaccounts (array[object]) - The subaccounts a subaccount-scoped user has access to, and their access level on each. Present only for subaccount-scoped users. For a full description, see [Subaccount access object](#header-subaccount-access-object).
     + options (object) - User-level options, present only when set.
 
 ### Retrieved user object
 
-Returned by [Retrieve a User](#header-retrieve-a-user). It differs from the [User object](#header-user-object) that List Users returns. This shape splits `name` into `first_name` and `last_name`, names the primary-account role `access_level` rather than `access`, and adds `created`, `updated`, and a `subaccounts` array that is always present.
+Returned by [Retrieve a User](#header-retrieve-a-user). This shape differs from the [User object](#header-user-object): `name` is split into `first_name` and `last_name`, the primary-account role is called `access_level` rather than `access`, and `created`, `updated`, and `subaccounts` are included.
 
-+ Data Structure: RetrievedUser
++ Data Structure: Attributes
     + username (string) - Unique username that identifies the user.
     + first_name (string) - The user's first name.
     + last_name (string) - The user's last name.
@@ -84,7 +92,7 @@ Returned by [Retrieve a User](#header-retrieve-a-user). It differs from the [Use
         + `reporting`
         + `templates`
         + `custom`
-    + access_policies (array) - The policies granted to the user when `access_level` is `custom`.
+    + `access_policies` (array[string]) - The [access policies](#header-access-policies) granted to the user when `access_level` is `custom`.
     + subaccount_id (number) - The subaccount the user is scoped to, if any. Omitted when `subaccounts` is non-empty.
     + is_sso (boolean) - Whether the user signs in via single sign-on.
     + email_verified (boolean) - Whether the user has verified their email address.
@@ -92,23 +100,37 @@ Returned by [Retrieve a User](#header-retrieve-a-user). It differs from the [Use
     + options (object) - User-level options, present only when set.
     + created (string) - ISO 8601 timestamp of when the user was created.
     + updated (string) - ISO 8601 timestamp of when the user was last updated.
-    + subaccounts (array) - The subaccounts the user has access to, and their access level on each. Always present, and an empty array for a user with no subaccount mappings. When it is non-empty, the top-level `access_level` and `subaccount_id` fields are omitted.
-        + (object)
-            + subaccount_id (number) - The subaccount ID.
-            + subaccount_name (string) - The subaccount's display name.
-            + access_level (enum) - The user's access level on the subaccount.
-                + `subaccount_reporting`
-                + `subaccount_developer`
-            + status (enum) - The subaccount's status.
-                + active
-                + suspended
-                + terminated
+    + subaccounts (array[object]) - The subaccounts the user has access to, and their access level on each. Always present, and an empty array for a user with no subaccount access. When it is non-empty, the top-level `access_level` and `subaccount_id` fields are omitted. For a full description, see [Subaccount access object](#header-subaccount-access-object).
+
+### Subaccount access object
+
+Each object in a user's `subaccounts` array describes one subaccount the user can reach, and the access level they hold on it.
+
++ Data Structure: Attributes
+    + subaccount_id (number) - The subaccount ID.
+    + subaccount_name (string) - The subaccount's display name.
+    + access_level (enum) - The user's access level on the subaccount.
+        + `subaccount_reporting`
+        + `subaccount_developer`
+    + status (enum) - The subaccount's status. Returned by [Retrieve a User](#header-retrieve-a-user) only.
+        + active
+        + suspended
+        + terminated
++ Sample
+    ```
+    {
+        "subaccount_id": 123,
+        "subaccount_name": "Joe's Garage",
+        "access_level": "subaccount_reporting",
+        "status": "active"
+    }
+    ```
 
 ### Invite object
 
 Returned by [List Pending Invites](#header-list-pending-invites).
 
-+ Data Structure: Invite
++ Data Structure: Attributes
     + id (string) - Unique ID for the pending invite. Use it to revoke the invite.
     + email (string) - The email address the invite was sent to.
     + from (string) - The email address of the user who created the invite.
@@ -120,151 +142,47 @@ Returned by [List Pending Invites](#header-list-pending-invites).
         + `custom`
     + expires (number) - Unix timestamp, in epoch seconds, at which the invitation expires.
 
+### Subaccount invite object
+
+Each object in the `subaccounts` array of an [Invite a User](#header-invite-a-user) request grants the invitee access to one subaccount.
+
++ Data Structure: Attributes
+    + subaccount_id (number, required) - The subaccount ID.
+    + access_level (enum, required) - The access level to grant on the subaccount.
+        + `subaccount_reporting`
+        + `subaccount_developer`
++ Sample
+    ```
+    {
+        "subaccount_id": 123,
+        "access_level": "subaccount_reporting"
+    }
+    ```
+
 ### Invite lifecycle
 
-* **Invitations expire after 3 days.** After that the registration link stops working.
-* **Expired invitations clean themselves up.** They drop off [List Pending Invites](#header-list-pending-invites) on expiry, so you never have to revoke them.
-* **There is no resend.** To give someone another chance to register, [invite the same email address again](#header-invite-a-user). That creates a second, independent invitation with its own expiry. The first one keeps working until it expires or you [revoke it](#header-revoke-a-pending-invite).
-* **Invites are rate limited.** Creating them too fast returns `429 Too Many Requests`. Back off and retry.
+Invitations expire after three days. The registration link then stops working and the invitation drops off [List Pending Invites](#header-list-pending-invites).
 
-### List Users [GET /v1/users]
-
-Returns the users on your account.
-
-+ Request
-
-    + Headers
-
-            Authorization: 14ac5499cfdd2bb2859e4476d2e5b1d2bad079bf
-            Accept: application/json
-
-+ Response 200 (application/json)
-
-        {
-            "results": [
-                {
-                    "name": "Ada Lovelace",
-                    "username": "ada",
-                    "email": "ada@example.com",
-                    "access": "admin",
-                    "is_sso": false,
-                    "email_verified": true,
-                    "tfa_enabled": false,
-                    "last_login": "2026-07-28T14:22:31.000Z"
-                },
-                {
-                    "name": "Grace Hopper",
-                    "username": "grace",
-                    "email": "grace@example.com",
-                    "access": "reporting",
-                    "is_sso": false,
-                    "email_verified": true,
-                    "tfa_enabled": true,
-                    "last_login": null
-                }
-            ]
-        }
-
-+ Response 403 (application/json)
-
-        {
-            "errors": [
-                {
-                    "message": "Forbidden"
-                }
-            ]
-        }
-
-### Retrieve a User [GET /v1/users/{username}]
-
-Returns one user by username, in the [Retrieved user object](#header-retrieved-user-object) shape rather than the [User object](#header-user-object) shape List Users returns.
-
-+ Parameters
-    + username (required, string, `grace`) - The username of the user to retrieve.
-
-+ Request
-
-    + Headers
-
-            Authorization: 14ac5499cfdd2bb2859e4476d2e5b1d2bad079bf
-            Accept: application/json
-
-+ Response 200 (application/json)
-
-        {
-            "results": {
-                "username": "grace",
-                "first_name": "Grace",
-                "last_name": "Hopper",
-                "email": "grace@example.com",
-                "access_level": "reporting",
-                "is_sso": false,
-                "email_verified": true,
-                "tfa_enabled": true,
-                "created": "2015-01-11T08:00:00.000Z",
-                "updated": "2018-04-11T08:00:00.000Z",
-                "subaccounts": []
-            }
-        }
-
-+ Response 200 (application/json)
-
-    A subaccount-scoped user.
-
-        {
-            "results": {
-                "username": "joe",
-                "first_name": "Joe",
-                "last_name": "Mechanic",
-                "email": "joe@example.com",
-                "is_sso": false,
-                "email_verified": true,
-                "tfa_enabled": false,
-                "created": "2015-01-11T08:00:00.000Z",
-                "updated": "2018-04-11T08:00:00.000Z",
-                "subaccounts": [
-                    {
-                        "subaccount_id": 123,
-                        "subaccount_name": "Joe's Garage",
-                        "access_level": "subaccount_reporting",
-                        "status": "active"
-                    }
-                ]
-            }
-        }
-
-+ Response 404 (application/json)
-
-        {
-            "errors": [
-                {
-                    "message": "User not found."
-                }
-            ]
-        }
+To give someone another chance to register, [invite the same email address again](#header-invite-a-user). That creates a second, independent invitation with its own expiry, and the first one keeps working until it expires or you [revoke it](#header-revoke-a-pending-invite).
 
 ### Invite a User [POST /v1/users/invite]
 
-The API has no direct, password-based user creation. New users join by invitation. This endpoint creates the invitation and emails a registration link. The invitee follows the link, sets their own password, and gets the role you named in `access_level`, subject to the [constraints](#header-constraints).
+Creates an invitation and emails a registration link to the address you supply. The invitee follows the link, sets their own password, and takes the role you named in `access_level`.
 
 Send `access_level` to invite a primary-account user, or `subaccounts` to invite a subaccount-scoped one. A `subaccounts` invite does not need a top-level `access_level`.
 
-The response carries only the invite `id`, which you use to [list](#header-list-pending-invites) and [revoke](#header-revoke-a-pending-invite) the invitation. The API never returns the registration token. It reaches the invitee only in the invitation email, so completing registration requires access to that mailbox.
+The response contains only the invite `id`, which you use to [list](#header-list-pending-invites) and [revoke](#header-revoke-a-pending-invite) the invitation. The registration token is sent in the invitation email and is never returned by the API.
 
 + Data Structure
     + email (string, required) - Email address of the person to invite. Maximum 512 characters.
-    + access_level (enum) - The primary-account role to assign. Required unless `subaccounts` is supplied. `admin` is not available to API keys, see [Constraints](#header-constraints).
+    + access_level (enum) - The primary-account role to assign. Required unless `subaccounts` is supplied. `admin` is not available to API keys.
         + `developer`
         + `reporting`
         + `templates`
         + `custom`
-    + access_policies (array) - The policies to grant. Only valid when `access_level` is `custom`.
-    + subaccounts (array) - Invite the user with access to one or more subaccounts instead of the primary account. Between 1 and 25 entries.
-        + (object)
-            + subaccount_id (number, required) - The subaccount ID.
-            + access_level (enum, required) - The subaccount access level.
-                + `subaccount_reporting`
-                + `subaccount_developer`
+    + `access_policies` (array[string]) - The [access policies](#header-access-policies) to grant. Only valid when `access_level` is `custom`.
+    + subaccounts (array[object]) - Invite the user with access to one or more subaccounts instead of the primary account. Between 1 and 25 entries. For a full description, see [Subaccount invite object](#header-subaccount-invite-object).
+
 
 + Request (application/json)
 
@@ -369,11 +287,130 @@ Revokes a pending invitation. Its registration link stops working immediately.
             ]
         }
 
-### Update a User [PUT /v1/users/{username}]
+### List Users [GET /v1/users]
 
-Changes a user's role. The body accepts `access_level` and `access_policies` and nothing else. Any other field returns `403`. Names, passwords, email addresses, and user options stay web-app only.
+Returns the users on your account.
 
-The [constraints](#header-constraints) apply here too. You cannot set a user to `admin`, and demoting the last `admin` returns `400`.
++ Request
+
+    + Headers
+
+            Authorization: 14ac5499cfdd2bb2859e4476d2e5b1d2bad079bf
+            Accept: application/json
+
++ Response 200 (application/json)
+
+        {
+            "results": [
+                {
+                    "name": "Ada Lovelace",
+                    "username": "ada",
+                    "email": "ada@example.com",
+                    "access": "admin",
+                    "is_sso": false,
+                    "email_verified": true,
+                    "tfa_enabled": false,
+                    "last_login": "2026-07-28T14:22:31.000Z"
+                },
+                {
+                    "name": "Katherine Johnson",
+                    "username": "katherine",
+                    "email": "katherine@example.com",
+                    "access": "custom",
+                    "access_policies": [
+                        "templates/full",
+                        "events/read",
+                        "signals_analytics/full"
+                    ],
+                    "is_sso": false,
+                    "email_verified": true,
+                    "tfa_enabled": true,
+                    "last_login": null
+                }
+            ]
+        }
+
++ Response 403 (application/json)
+
+        {
+            "errors": [
+                {
+                    "message": "Forbidden"
+                }
+            ]
+        }
+
+### Retrieve a User [GET /v1/users/{username}]
+
+Returns one user by username, in the [Retrieved user object](#header-retrieved-user-object) shape.
+
++ Parameters
+    + username (required, string, `grace`) - The username of the user to retrieve.
+
++ Request
+
+    + Headers
+
+            Authorization: 14ac5499cfdd2bb2859e4476d2e5b1d2bad079bf
+            Accept: application/json
+
++ Response 200 (application/json)
+
+        {
+            "results": {
+                "username": "grace",
+                "first_name": "Grace",
+                "last_name": "Hopper",
+                "email": "grace@example.com",
+                "access_level": "reporting",
+                "is_sso": false,
+                "email_verified": true,
+                "tfa_enabled": true,
+                "created": "2015-01-11T08:00:00.000Z",
+                "updated": "2018-04-11T08:00:00.000Z",
+                "subaccounts": []
+            }
+        }
+
++ Response 200 (application/json)
+
+    A subaccount-scoped user.
+
+        {
+            "results": {
+                "username": "joe",
+                "first_name": "Joe",
+                "last_name": "Mechanic",
+                "email": "joe@example.com",
+                "is_sso": false,
+                "email_verified": true,
+                "tfa_enabled": false,
+                "created": "2015-01-11T08:00:00.000Z",
+                "updated": "2018-04-11T08:00:00.000Z",
+                "subaccounts": [
+                    {
+                        "subaccount_id": 123,
+                        "subaccount_name": "Joe's Garage",
+                        "access_level": "subaccount_reporting",
+                        "status": "active"
+                    }
+                ]
+            }
+        }
+
++ Response 404 (application/json)
+
+        {
+            "errors": [
+                {
+                    "message": "User not found."
+                }
+            ]
+        }
+
+### Update a User's Role [PUT /v1/users/{username}]
+
+The body accepts `access_level` and `access_policies` only.
 
 + Data Structure
     + access_level (enum) - The primary-account role to assign.
@@ -381,7 +418,8 @@ The [constraints](#header-constraints) apply here too. You cannot set a user to 
         + `reporting`
         + `templates`
         + `custom`
-    + access_policies (array) - The policies to grant. Only valid when `access_level` is `custom`.
+    + `access_policies` (array[string]) - The [access policies](#header-access-policies) to grant. Only valid when `access_level` is `custom`.
+
 
 + Parameters
     + username (required, string, `grace`) - The username of the user to update.
@@ -428,9 +466,7 @@ The [constraints](#header-constraints) apply here too. You cannot set a user to 
 
 ### Delete a User [DELETE /v1/users/{username}]
 
-Deletes a user from your account.
-
-You cannot delete the owner of the key you are calling with, a user on a different account, or the account's last `admin`.
+Deletes a user from your account. You cannot delete the owner of the key you are calling with, a user on a different account, or the account's last `admin`.
 
 + Parameters
     + username (required, string, `grace`) - The username of the user to delete.
@@ -473,17 +509,18 @@ You cannot delete the owner of the key you are calling with, a user on a differe
             ]
         }
 
-### Add a Subaccount Mapping [POST /v1/users/{username}/subaccounts]
+### Grant Subaccount Access [POST /v1/users/{username}/subaccounts]
 
 Grants a user access to a subaccount at the given access level. If the user already has access to that subaccount, the call updates their access level instead.
 
-This endpoint adds subaccounts to a user who is already subaccount-scoped, so the target needs at least one mapping to begin with. Calling it for a primary-account user returns `400`. To give a new person subaccount access, [invite them](#header-invite-a-user) with a `subaccounts` array.
+The user must already have access to at least one subaccount. Calling this endpoint for a primary-account user returns `400`. To give a new person subaccount access, [invite them](#header-invite-a-user) with a `subaccounts` array.
 
 + Data Structure
     + subaccount_id (number, required) - The subaccount to grant access to.
     + access_level (enum, required) - The access level to grant on the subaccount.
         + `subaccount_reporting`
         + `subaccount_developer`
+
 
 + Parameters
     + username (required, string, `grace`) - The username of the user.
@@ -521,7 +558,7 @@ This endpoint adds subaccounts to a user who is already subaccount-scoped, so th
 
 + Response 400 (application/json)
 
-    The user has no subaccount mappings.
+    The user is not subaccount-scoped.
 
         {
             "errors": [
@@ -531,11 +568,9 @@ This endpoint adds subaccounts to a user who is already subaccount-scoped, so th
             ]
         }
 
-### Remove a Subaccount Mapping [DELETE /v1/users/{username}/subaccounts/{subaccountId}]
+### Revoke Subaccount Access [DELETE /v1/users/{username}/subaccounts/{subaccountId}]
 
-Removes a user's access to a subaccount.
-
-A subaccount-scoped user must keep at least one subaccount, so removing the last mapping returns `400`. [Delete the user](#header-delete-a-user) instead.
+Removes a user's access to a subaccount. A subaccount-scoped user must keep at least one subaccount, so revoking the last one returns `400`. [Delete the user](#header-delete-a-user) instead.
 
 + Parameters
     + username (required, string, `grace`) - The username of the user.

--- a/content/api/users.apib
+++ b/content/api/users.apib
@@ -171,7 +171,7 @@ The response contains the invite `id`, which you use to [list](#header-list-pend
 
 + Data Structure
     + email (string, required) - Email address of the person to invite. Maximum 512 characters.
-    + access_level (enum) - The primary-account [role](#header-roles) to assign. Required unless `subaccounts` is supplied. `admin` is not available to API keys.
+    + access_level (enum) - The primary-account [role](#header-roles) to assign. Required unless `subaccounts` is supplied. `admin` cannot be set through the API.
         + `developer`
         + `reporting`
         + `templates`
@@ -411,7 +411,7 @@ Returns one user by username, in the [User object](#header-user-object) shape.
 ### Update a User's Role [PUT /v1/users/{username}]
 
 + Data Structure
-    + access_level (enum) - The primary-account [role](#header-roles) to assign.
+    + access_level (enum) - The primary-account [role](#header-roles) to assign. `admin` cannot be set through the API.
         + `developer`
         + `reporting`
         + `templates`

--- a/content/api/users.apib
+++ b/content/api/users.apib
@@ -568,7 +568,7 @@ The user must already have access to at least one subaccount. Calling this endpo
 
 ### Revoke Subaccount Access [DELETE /v1/users/{username}/subaccounts/{subaccountId}]
 
-Removes a user's access to a subaccount. A subaccount-scoped user must keep at least one subaccount, so revoking the last one returns `400`. [Delete the user](#header-delete-a-user) instead.
+Removes a user's access to a subaccount.
 
 + Parameters
     + username (required, string, `grace`) - The username of the user.

--- a/content/api/users.apib
+++ b/content/api/users.apib
@@ -45,14 +45,16 @@ A user with the `custom` role gets exactly the policies you list in `access_poli
 
 ### User object
 
-Returned by [List Users](#header-list-users) and [Retrieve a User](#header-retrieve-a-user). Both use the same field names. Retrieve returns three things List does not: `created`, `updated`, and a `status` on each entry of `subaccounts`.
+Returned by [List Users](#header-list-users) and [Retrieve a User](#header-retrieve-a-user).
+
+Every user is scoped either to the account or to one or more subaccounts. An account-scoped user has an `access_level`. A subaccount-scoped user has none, and holds a role on each subaccount instead.
 
 + Data Structure: Attributes
     + username (string) - Unique username that identifies the user.
-    + first_name (string, nullable) - The user's first name. `null` if they have not set one.
-    + last_name (string, nullable) - The user's last name. `null` if they have not set one.
+    + first_name (string, nullable) - The user's first name.
+    + last_name (string, nullable) - The user's last name.
     + email (string) - The user's email address.
-    + access_level (enum) - The user's primary-account role. Omitted for subaccount-scoped users.
+    + access_level (enum) - The user's role on the account. Absent for subaccount-scoped users.
         + `admin`
         + `developer`
         + `reporting`
@@ -63,11 +65,26 @@ Returned by [List Users](#header-list-users) and [Retrieve a User](#header-retri
     + email_verified (boolean) - Whether the user has verified their email address.
     + tfa_enabled (boolean) - Whether the user has two-factor authentication enabled.
     + last_login (string, nullable) - ISO 8601 timestamp of the user's last sign-in, or `null` if they have never signed in.
-    + subaccount_id (number) - The subaccount the user is scoped to, if any. [Retrieve a User](#header-retrieve-a-user) omits it when `subaccounts` is non-empty.
-    + subaccounts (array[object]) - The subaccounts the user has access to, and their access level on each. For a full description, see [Subaccount access object](#header-subaccount-access-object). [Retrieve a User](#header-retrieve-a-user) always returns this field, as an empty array for a user with no subaccount access, and omits the top-level `access_level` when it is non-empty. [List Users](#header-list-users) returns it only for subaccount-scoped users.
-    + options (object) - User-level options, present only when set.
+    + subaccounts (array[object]) - The subaccounts the user can reach, and their role on each. See [Subaccount access object](#header-subaccount-access-object). Returned by [Retrieve a User](#header-retrieve-a-user) only, and empty for an account-scoped user.
     + created (string) - ISO 8601 timestamp of when the user was created. Returned by [Retrieve a User](#header-retrieve-a-user) only.
     + updated (string) - ISO 8601 timestamp of when the user was last updated. Returned by [Retrieve a User](#header-retrieve-a-user) only.
++ Sample
+    ```
+    {
+        "username": "grace",
+        "first_name": "Grace",
+        "last_name": "Hopper",
+        "email": "grace@example.com",
+        "access_level": "reporting",
+        "is_sso": false,
+        "email_verified": true,
+        "tfa_enabled": true,
+        "last_login": "2026-08-02T09:14:05.000Z",
+        "created": "2015-01-11T08:00:00.000Z",
+        "updated": "2018-04-11T08:00:00.000Z",
+        "subaccounts": []
+    }
+    ```
 
 ### Subaccount access object
 
@@ -108,6 +125,16 @@ Returned by [List Pending Invites](#header-list-pending-invites).
         + `templates`
         + `custom`
     + expires (number) - Unix timestamp, in epoch seconds, at which the invitation expires.
++ Sample
+    ```
+    {
+        "id": "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
+        "email": "newuser@example.com",
+        "from": "ada@example.com",
+        "access_level": "reporting",
+        "expires": 1720656000
+    }
+    ```
 
 ### Subaccount invite object
 
@@ -138,7 +165,7 @@ Creates an invitation and emails a registration link to the address you supply. 
 
 Send `access_level` to invite a primary-account user, or `subaccounts` to invite a subaccount-scoped one. A `subaccounts` invite does not need a top-level `access_level`.
 
-The response contains only the invite `id`, which you use to [list](#header-list-pending-invites) and [revoke](#header-revoke-a-pending-invite) the invitation. The registration token is sent in the invitation email and is never returned by the API.
+The response contains the invite `id`, which you use to [list](#header-list-pending-invites) and [revoke](#header-revoke-a-pending-invite) the invitation.
 
 + Data Structure
     + email (string, required) - Email address of the person to invite. Maximum 512 characters.
@@ -381,10 +408,8 @@ Returns one user by username, in the [User object](#header-user-object) shape.
 
 ### Update a User's Role [PUT /v1/users/{username}]
 
-The body accepts `access_level` and `access_policies` only.
-
 + Data Structure
-    + access_level (enum) - The primary-account role to assign.
+    + access_level (enum) - The primary-account [role](#header-roles) to assign.
         + `developer`
         + `reporting`
         + `templates`
@@ -437,7 +462,7 @@ The body accepts `access_level` and `access_policies` only.
 
 ### Delete a User [DELETE /v1/users/{username}]
 
-Deletes a user from your account. You cannot delete the owner of the key you are calling with, a user on a different account, or the account's last `admin`.
+Deletes a user from your account.
 
 + Parameters
     + username (required, string, `grace`) - The username of the user to delete.

--- a/content/api/users.apib
+++ b/content/api/users.apib
@@ -371,21 +371,18 @@ Revokes a pending invitation so its registration link can no longer be used.
 
 ### Update a User [PUT /v1/users/{username}]
 
-Updates an existing user. Through this endpoint you can change the following fields: `first_name`, `last_name`, `access_level` (and, when `access_level` is `custom`, `access_policies`), and `options`.
+Changes a user's role. The request accepts only `access_level` (and `access_policies` when `access_level` is `custom`); a request that contains any other field is rejected with `403 Forbidden`.
 
 Changing `access_level` is subject to the [role ceiling](#header-constraints), and demoting the account's last `admin` is rejected with `400`.
 
 + Data Structure
-    + first_name (string) - The user's first name.
-    + last_name (string) - The user's last name.
-    + access_level (enum) - The primary-account role to assign.
+    + access_level (enum, required) - The primary-account role to assign.
         + `admin`
         + `developer`
         + `reporting`
         + `templates`
         + `custom`
-    + access_policies (array) - The policies to grant. Only valid when `access_level` is `custom`.
-    + options (object) - User-level options.
+    + access_policies (array) - The policies to grant. Required when `access_level` is `custom`, and not allowed otherwise.
 
 + Parameters
     + username (required, string, `grace`) - The username of the user to update.
@@ -399,8 +396,6 @@ Changing `access_level` is subject to the [role ceiling](#header-constraints), a
     + Body
 
             {
-                "first_name": "Grace",
-                "last_name": "Hopper",
                 "access_level": "developer"
             }
 

--- a/content/api/users.apib
+++ b/content/api/users.apib
@@ -60,7 +60,7 @@ Every user is scoped either to the account or to one or more subaccounts. An acc
         + `reporting`
         + `templates`
         + `custom`
-    + `access_policies` (array[string]) - The [access policies](#header-access-policies) granted to the user when `access_level` is `custom`.
+    + `access_policies` (array[string]) - The [access policies](#header-access-policies) granted to the user. Only present when `access_level` is `custom`.
     + is_sso (boolean) - Whether the user signs in via single sign-on.
     + email_verified (boolean) - Whether the user has verified their email address.
     + tfa_enabled (boolean) - Whether the user has two-factor authentication enabled.

--- a/content/api/users.apib
+++ b/content/api/users.apib
@@ -4,22 +4,22 @@ description: Programmatically manage the users on your SparkPost account with an
 
 # Group Users
 
-The Users API lets you list, invite, update, and remove the users on your account, and manage each user's subaccount access, using an API key rather than the web app.
+Use the Users API to manage your account's users from code instead of the web app. You can list users, invite new ones, change roles, remove users, and manage each user's subaccount access.
 
 ### Prerequisites
 
-To call the Users API, an API key must hold one of two grants, and an **admin** must attach the grant to the key through the web app's [API Keys page](https://app.sparkpost.com/account/api-keys). A grant cannot be attached by another API key. Both are `api_key`-role grants.
+Every call needs an API key holding one of two grants. Only an admin can attach either grant, and only from the web app's [API Keys page](https://app.sparkpost.com/account/api-keys). No API key can attach a grant, not even a key that already holds one.
 
-* **`Users: View`** — read-only access, covering the `GET` endpoints only: [List Users](#header-list-users), [Retrieve a User](#header-retrieve-a-user), and [List Pending Invites](#header-list-pending-invites).
-* **`Users: Manage`** — full management. Every write endpoint (invite, update, delete, and the subaccount-mapping changes) requires this grant.
+* **`Users: View`** gives read-only access to the three `GET` endpoints: [List Users](#header-list-users), [Retrieve a User](#header-retrieve-a-user), and [List Pending Invites](#header-list-pending-invites).
+* **`Users: Manage`** covers the same reads plus every write: invite, update, delete, and the subaccount-mapping changes.
 
-Requests made with a key that holds neither grant, or that attempt a write with only `Users: View`, are rejected with `403 Forbidden`.
+A key holding neither grant gets `403`, and so does a write attempted with only `Users: View`.
 
-<Banner status="info">These grants are intentionally narrower than the user management available in the web app. They do <strong>not</strong> cover two-factor authentication, email verification, SCIM provisioning, or password endpoints, and they do not allow direct password-based user creation (see <a href="#header-invite-a-user">Invite a User</a>).</Banner>
+<Banner status="info">These grants cover less than the web app's user management. They do not reach two-factor authentication, email verification, SCIM provisioning, or password endpoints, and they cannot create a user directly with a password. New users join by <a href="#header-invite-a-user">invitation</a>.</Banner>
 
 ### Roles
 
-When you invite or update a user you assign a **role** through the `access_level` field. The primary-account roles are:
+Inviting or updating a user assigns a role through the `access_level` field. The primary-account roles are:
 
 | Role | Description |
 |-------------|-------------------------------------------------------------|
@@ -29,15 +29,16 @@ When you invite or update a user you assign a **role** through the `access_level
 | `templates` | Access limited to managing templates. |
 | `custom` | A role whose permissions are defined by the `access_policies` you supply. |
 
-Subaccount access levels (used only in the `subaccounts` array and in the subaccount-mapping endpoints) are `subaccount_reporting` and `subaccount_developer`.
+Subaccount-scoped users take one of two access levels instead, `subaccount_reporting` or `subaccount_developer`. These appear only in the `subaccounts` array and in the subaccount-mapping endpoints.
 
 ### Constraints
 
-The following rules are enforced on every Users API request. They protect against privilege escalation and account lockout:
+These rules apply to every Users API request. They stop a key from escalating its own privileges or locking an account out of its own administration.
 
-* **Role ceiling.** You can never create or invite a user, or raise a user to a role, more privileged than the role of the user who owns the API key. An admin-owned key can assign up to `admin`; a key owned by a less-privileged user is bounded by that user's role.
-* **Last admin protection.** The last `admin` on an account cannot be deleted or demoted through the API. Such a request is rejected with `400`.
-* **Key revocation on owner deletion.** If the admin user who owns a key holding the `Users: Manage` grant is deleted, that key is revoked rather than reassigned to another user.
+* **No admin through the API.** An API key never assigns the `admin` role, not even a key owned by an admin. Inviting a user as `admin` returns `403`, and so does promoting one. Create admins in the web app.
+* **Role ceiling.** Below admin, a key can only grant a role at or under the role held by the user who owns it. A key owned by a `reporting` user invites `reporting` users and nothing higher.
+* **Last admin protection.** The API refuses to delete or demote the last `admin` on an account, returning `400`.
+* **Self-deletion.** A key cannot delete its own owner.
 
 ### User object
 
@@ -47,7 +48,7 @@ Returned by [List Users](#header-list-users).
     + name (string) - The user's display name, derived from their first and last name.
     + username (string) - Unique username that identifies the user.
     + email (string) - The user's email address.
-    + access (enum) - The user's primary-account role. Empty for subaccount-scoped users.
+    + access (enum) - The user's primary-account role. Omitted for subaccount-scoped users.
         + `admin`
         + `developer`
         + `reporting`
@@ -57,6 +58,7 @@ Returned by [List Users](#header-list-users).
     + is_sso (boolean) - Whether the user signs in via single sign-on.
     + email_verified (boolean) - Whether the user has verified their email address.
     + tfa_enabled (boolean) - Whether the user has two-factor authentication enabled.
+    + last_login (string, nullable) - ISO 8601 timestamp of the user's last sign-in, or `null` if they have never signed in.
     + subaccount_id (number) - The subaccount the user is scoped to, if any.
     + subaccounts (array) - The subaccounts a subaccount-scoped user has access to, and their access level on each. Present only for subaccount-scoped users.
         + (object)
@@ -69,7 +71,7 @@ Returned by [List Users](#header-list-users).
 
 ### Retrieved user object
 
-Returned by [Retrieve a User](#header-retrieve-a-user). This is a richer shape than the [User object](#header-user-object) returned by List Users: it has `first_name` and `last_name` in place of `name`, uses `access_level` for the primary-account role, and adds `created`, `updated`, and an always-present `subaccounts` array.
+Returned by [Retrieve a User](#header-retrieve-a-user). It differs from the [User object](#header-user-object) that List Users returns. This shape splits `name` into `first_name` and `last_name`, names the primary-account role `access_level` rather than `access`, and adds `created`, `updated`, and a `subaccounts` array that is always present.
 
 + Data Structure: RetrievedUser
     + username (string) - Unique username that identifies the user.
@@ -90,7 +92,7 @@ Returned by [Retrieve a User](#header-retrieve-a-user). This is a richer shape t
     + options (object) - User-level options, present only when set.
     + created (string) - ISO 8601 timestamp of when the user was created.
     + updated (string) - ISO 8601 timestamp of when the user was last updated.
-    + subaccounts (array) - The subaccounts the user has access to, and their access level on each. Always present; an empty array for a user with no subaccount mappings. When it is non-empty, the top-level `access_level` and `subaccount_id` fields are omitted.
+    + subaccounts (array) - The subaccounts the user has access to, and their access level on each. Always present, and an empty array for a user with no subaccount mappings. When it is non-empty, the top-level `access_level` and `subaccount_id` fields are omitted.
         + (object)
             + subaccount_id (number) - The subaccount ID.
             + subaccount_name (string) - The subaccount's display name.
@@ -110,7 +112,7 @@ Returned by [List Pending Invites](#header-list-pending-invites).
     + id (string) - Unique ID for the pending invite. Use it to revoke the invite.
     + email (string) - The email address the invite was sent to.
     + from (string) - The email address of the user who created the invite.
-    + access_level (enum) - The role the invited user will be assigned when they register.
+    + access_level (enum) - The role the user takes on when they register.
         + `admin`
         + `developer`
         + `reporting`
@@ -120,10 +122,10 @@ Returned by [List Pending Invites](#header-list-pending-invites).
 
 ### Invite lifecycle
 
-* **Invitations expire after 3 days.** Once an invitation expires, its registration link no longer works.
-* **Expired invitations are removed automatically.** They stop appearing in [List Pending Invites](#header-list-pending-invites) once they expire; you do not need to clean them up.
-* **There is no resend.** To give someone another chance to register, [invite the same email address again](#header-invite-a-user). This creates a new, independent invitation with its own token and expiry; the earlier invitation keeps working until it expires or you [revoke it](#header-revoke-a-pending-invite).
-* **Invite creation is rate limited.** If you create invitations too quickly, requests are rejected with `429 Too Many Requests`. Wait before retrying.
+* **Invitations expire after 3 days.** After that the registration link stops working.
+* **Expired invitations clean themselves up.** They drop off [List Pending Invites](#header-list-pending-invites) on expiry, so you never have to revoke them.
+* **There is no resend.** To give someone another chance to register, [invite the same email address again](#header-invite-a-user). That creates a second, independent invitation with its own expiry. The first one keeps working until it expires or you [revoke it](#header-revoke-a-pending-invite).
+* **Invites are rate limited.** Creating them too fast returns `429 Too Many Requests`. Back off and retry.
 
 ### List Users [GET /v1/users]
 
@@ -147,7 +149,8 @@ Returns the users on your account.
                     "access": "admin",
                     "is_sso": false,
                     "email_verified": true,
-                    "tfa_enabled": false
+                    "tfa_enabled": false,
+                    "last_login": "2026-07-28T14:22:31.000Z"
                 },
                 {
                     "name": "Grace Hopper",
@@ -156,7 +159,8 @@ Returns the users on your account.
                     "access": "reporting",
                     "is_sso": false,
                     "email_verified": true,
-                    "tfa_enabled": true
+                    "tfa_enabled": true,
+                    "last_login": null
                 }
             ]
         }
@@ -173,7 +177,7 @@ Returns the users on your account.
 
 ### Retrieve a User [GET /v1/users/{username}]
 
-Returns a single user by username. The response uses the [Retrieved user object](#header-retrieved-user-object) shape, which differs from the [User object](#header-user-object) returned by List Users.
+Returns one user by username, in the [Retrieved user object](#header-retrieved-user-object) shape rather than the [User object](#header-user-object) shape List Users returns.
 
 + Parameters
     + username (required, string, `grace`) - The username of the user to retrieve.
@@ -234,25 +238,22 @@ Returns a single user by username. The response uses the [Retrieved user object]
         {
             "errors": [
                 {
-                    "message": "User does not exist"
+                    "message": "User not found."
                 }
             ]
         }
 
 ### Invite a User [POST /v1/users/invite]
 
-There is no direct, password-based user creation through the API — users are created by **invitation** only. This endpoint creates an invitation and emails the invitee a registration link; the invitee completes registration through that link and sets their own password. The invited user's role is set by `access_level` and is bounded by the [role ceiling](#header-constraints).
+The API has no direct, password-based user creation. New users join by invitation. This endpoint creates the invitation and emails a registration link. The invitee follows the link, sets their own password, and gets the role you named in `access_level`, subject to the [constraints](#header-constraints).
 
-Provide `access_level` for a primary-account user, or `subaccounts` to invite a subaccount-scoped user. When `subaccounts` is supplied, a top-level `access_level` is not required.
+Send `access_level` to invite a primary-account user, or `subaccounts` to invite a subaccount-scoped one. A `subaccounts` invite does not need a top-level `access_level`.
 
-The response contains the invite `token`.
-
-<Banner status="danger"><strong>Treat the invite <code>token</code> as a credential.</strong> Anyone who holds the token can complete registration as the invited user. Invited users normally complete registration through the emailed link, so you do not need to handle the token yourself; if you do capture it, store and transmit it as securely as you would a password, and never log or share it.</Banner>
+The response carries only the invite `id`, which you use to [list](#header-list-pending-invites) and [revoke](#header-revoke-a-pending-invite) the invitation. The API never returns the registration token. It reaches the invitee only in the invitation email, so completing registration requires access to that mailbox.
 
 + Data Structure
-    + email (string, required) - Email address of the person to invite. Max length: 512 characters.
-    + access_level (enum) - The primary-account role to assign. Required unless `subaccounts` is supplied.
-        + `admin`
+    + email (string, required) - Email address of the person to invite. Maximum 512 characters.
+    + access_level (enum) - The primary-account role to assign. Required unless `subaccounts` is supplied. `admin` is not available to API keys, see [Constraints](#header-constraints).
         + `developer`
         + `reporting`
         + `templates`
@@ -282,8 +283,7 @@ The response contains the invite `token`.
 
         {
             "results": {
-                "id": "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
-                "token": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"
+                "id": "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
             }
         }
 
@@ -304,7 +304,7 @@ The response contains the invite `token`.
         {
             "errors": [
                 {
-                    "message": "Forbidden"
+                    "message": "API keys cannot invite an admin-level user."
                 }
             ]
         }
@@ -321,7 +321,7 @@ The response contains the invite `token`.
 
 ### List Pending Invites [GET /v1/users/pending-invites]
 
-Returns the invitations on your account that have not yet been accepted. Expired invitations are not included.
+Returns the invitations on your account that nobody has accepted yet. Expired invitations do not appear.
 
 + Request
 
@@ -346,7 +346,7 @@ Returns the invitations on your account that have not yet been accepted. Expired
 
 ### Revoke a Pending Invite [DELETE /v1/users/pending-invites/{id}]
 
-Revokes a pending invitation so its registration link can no longer be used.
+Revokes a pending invitation. Its registration link stops working immediately.
 
 + Parameters
     + id (required, string, `3f2504e0-4f89-41d3-9a0c-0305e82c3301`) - The invite ID from [List Pending Invites](#header-list-pending-invites).
@@ -371,18 +371,17 @@ Revokes a pending invitation so its registration link can no longer be used.
 
 ### Update a User [PUT /v1/users/{username}]
 
-Changes a user's role. The request accepts only `access_level` (and `access_policies` when `access_level` is `custom`); a request that contains any other field is rejected with `403 Forbidden`.
+Changes a user's role. The body accepts `access_level` and `access_policies` and nothing else. Any other field returns `403`. Names, passwords, email addresses, and user options stay web-app only.
 
-Changing `access_level` is subject to the [role ceiling](#header-constraints), and demoting the account's last `admin` is rejected with `400`.
+The [constraints](#header-constraints) apply here too. You cannot set a user to `admin`, and demoting the last `admin` returns `400`.
 
 + Data Structure
-    + access_level (enum, required) - The primary-account role to assign.
-        + `admin`
+    + access_level (enum) - The primary-account role to assign.
         + `developer`
         + `reporting`
         + `templates`
         + `custom`
-    + access_policies (array) - The policies to grant. Required when `access_level` is `custom`, and not allowed otherwise.
+    + access_policies (array) - The policies to grant. Only valid when `access_level` is `custom`.
 
 + Parameters
     + username (required, string, `grace`) - The username of the user to update.
@@ -422,7 +421,7 @@ Changing `access_level` is subject to the [role ceiling](#header-constraints), a
         {
             "errors": [
                 {
-                    "message": "Forbidden"
+                    "message": "API keys may only modify access_level and access_policies."
                 }
             ]
         }
@@ -431,7 +430,7 @@ Changing `access_level` is subject to the [role ceiling](#header-constraints), a
 
 Deletes a user from your account.
 
-You cannot delete the user who owns the API key you are calling with, a user that belongs to a different account, or the account's last `admin`.
+You cannot delete the owner of the key you are calling with, a user on a different account, or the account's last `admin`.
 
 + Parameters
     + username (required, string, `grace`) - The username of the user to delete.
@@ -459,7 +458,7 @@ You cannot delete the user who owns the API key you are calling with, a user tha
         {
             "errors": [
                 {
-                    "message": "Forbidden"
+                    "message": "Cannot delete current user."
                 }
             ]
         }
@@ -476,7 +475,9 @@ You cannot delete the user who owns the API key you are calling with, a user tha
 
 ### Add a Subaccount Mapping [POST /v1/users/{username}/subaccounts]
 
-Grants a user access to a subaccount at the given access level. If the user already has access to the subaccount, the access level is updated.
+Grants a user access to a subaccount at the given access level. If the user already has access to that subaccount, the call updates their access level instead.
+
+This endpoint adds subaccounts to a user who is already subaccount-scoped, so the target needs at least one mapping to begin with. Calling it for a primary-account user returns `400`. To give a new person subaccount access, [invite them](#header-invite-a-user) with a `subaccounts` array.
 
 + Data Structure
     + subaccount_id (number, required) - The subaccount to grant access to.
@@ -518,13 +519,27 @@ Grants a user access to a subaccount at the given access level. If the user alre
             ]
         }
 
++ Response 400 (application/json)
+
+    The user has no subaccount mappings.
+
+        {
+            "errors": [
+                {
+                    "message": "Invalid user"
+                }
+            ]
+        }
+
 ### Remove a Subaccount Mapping [DELETE /v1/users/{username}/subaccounts/{subaccountId}]
 
 Removes a user's access to a subaccount.
 
+A subaccount-scoped user must keep at least one subaccount, so removing the last mapping returns `400`. [Delete the user](#header-delete-a-user) instead.
+
 + Parameters
     + username (required, string, `grace`) - The username of the user.
-    + subaccountId (required, number, `123`) - The subaccount to remove access to.
+    + subaccountId (required, number, `123`) - The subaccount to revoke access to.
 
 + Request
 
@@ -533,3 +548,13 @@ Removes a user's access to a subaccount.
             Authorization: 14ac5499cfdd2bb2859e4476d2e5b1d2bad079bf
 
 + Response 204
+
++ Response 400 (application/json)
+
+        {
+            "errors": [
+                {
+                    "message": "Cannot delete last subaccount for user"
+                }
+            ]
+        }

--- a/content/api/users.apib
+++ b/content/api/users.apib
@@ -561,7 +561,7 @@ The user must already have access to at least one subaccount. Calling this endpo
         {
             "errors": [
                 {
-                    "message": "Invalid user"
+                    "message": "User is not subaccount-scoped"
                 }
             ]
         }

--- a/content/api/users.apib
+++ b/content/api/users.apib
@@ -126,7 +126,7 @@ Returned by [List Pending Invites](#header-list-pending-invites).
         + `custom`
     + `access_policies` (array[string]) - The [access policies](#header-access-policies) the user takes on when they register, if `access_level` is `custom`.
     + subaccounts (array[object]) - The subaccount access the user takes on when they register. See [Subaccount invite object](#header-subaccount-invite-object). Present instead of `access_level` for a subaccount-scoped invite.
-    + expires (number) - Unix timestamp, in epoch seconds, at which the invitation expires.
+    + expires (string) - ISO 8601 timestamp at which the invitation expires.
 + Sample
     ```
     {
@@ -134,7 +134,7 @@ Returned by [List Pending Invites](#header-list-pending-invites).
         "email": "newuser@example.com",
         "from": "ada@example.com",
         "access_level": "reporting",
-        "expires": 1720656000
+        "expires": "2024-07-11T00:00:00.000Z"
     }
     ```
 
@@ -253,7 +253,7 @@ Returns the invitations on your account that nobody has accepted yet. Expired in
                     "email": "newuser@example.com",
                     "from": "ada@example.com",
                     "access_level": "reporting",
-                    "expires": 1720656000
+                    "expires": "2024-07-11T00:00:00.000Z"
                 }
             ]
         }

--- a/content/api/users.apib
+++ b/content/api/users.apib
@@ -5,18 +5,7 @@ label: New
 
 # Group Users
 
-Use the Users API to manage the users on your account: list them, invite new ones, change their roles, and remove them.
-
-### Grants
-
-Every request needs an API key with one of two grants:
-
-* `Users: View` allows the three `GET` endpoints: [List Users](#header-list-users), [Retrieve a User](#header-retrieve-a-user), and [List Pending Invites](#header-list-pending-invites).
-* `Users: Manage` allows those reads plus every write: invite, update, and delete.
-
-Only an admin can add these grants, and only from the web app's [API Keys page](https://app.sparkpost.com/account/api-keys).
-
-A key with neither grant returns `403`, as does a write attempted with only `Users: View`.
+Manage the users on your account: list, invite new ones, change their roles, and remove them.
 
 ### Roles
 
@@ -56,35 +45,12 @@ A user with the `custom` role gets exactly the policies you list in `access_poli
 
 ### User object
 
-Returned by [List Users](#header-list-users).
-
-+ Data Structure: Attributes
-    + name (string) - The user's display name, derived from their first and last name.
-    + username (string) - Unique username that identifies the user.
-    + email (string) - The user's email address.
-    + access (enum) - The user's primary-account role. Omitted for subaccount-scoped users.
-        + `admin`
-        + `developer`
-        + `reporting`
-        + `templates`
-        + `custom`
-    + `access_policies` (array[string]) - The [access policies](#header-access-policies) granted to the user when `access` is `custom`.
-    + is_sso (boolean) - Whether the user signs in via single sign-on.
-    + email_verified (boolean) - Whether the user has verified their email address.
-    + tfa_enabled (boolean) - Whether the user has two-factor authentication enabled.
-    + last_login (string, nullable) - ISO 8601 timestamp of the user's last sign-in, or `null` if they have never signed in.
-    + subaccount_id (number) - The subaccount the user is scoped to, if any.
-    + subaccounts (array[object]) - The subaccounts a subaccount-scoped user has access to, and their access level on each. Present only for subaccount-scoped users. For a full description, see [Subaccount access object](#header-subaccount-access-object).
-    + options (object) - User-level options, present only when set.
-
-### Retrieved user object
-
-Returned by [Retrieve a User](#header-retrieve-a-user). This shape differs from the [User object](#header-user-object): `name` is split into `first_name` and `last_name`, the primary-account role is called `access_level` rather than `access`, and `created`, `updated`, and `subaccounts` are included.
+Returned by [List Users](#header-list-users) and [Retrieve a User](#header-retrieve-a-user). Both use the same field names. Retrieve returns three things List does not: `created`, `updated`, and a `status` on each entry of `subaccounts`.
 
 + Data Structure: Attributes
     + username (string) - Unique username that identifies the user.
-    + first_name (string) - The user's first name.
-    + last_name (string) - The user's last name.
+    + first_name (string, nullable) - The user's first name. `null` if they have not set one.
+    + last_name (string, nullable) - The user's last name. `null` if they have not set one.
     + email (string) - The user's email address.
     + access_level (enum) - The user's primary-account role. Omitted for subaccount-scoped users.
         + `admin`
@@ -93,14 +59,15 @@ Returned by [Retrieve a User](#header-retrieve-a-user). This shape differs from 
         + `templates`
         + `custom`
     + `access_policies` (array[string]) - The [access policies](#header-access-policies) granted to the user when `access_level` is `custom`.
-    + subaccount_id (number) - The subaccount the user is scoped to, if any. Omitted when `subaccounts` is non-empty.
     + is_sso (boolean) - Whether the user signs in via single sign-on.
     + email_verified (boolean) - Whether the user has verified their email address.
     + tfa_enabled (boolean) - Whether the user has two-factor authentication enabled.
+    + last_login (string, nullable) - ISO 8601 timestamp of the user's last sign-in, or `null` if they have never signed in.
+    + subaccount_id (number) - The subaccount the user is scoped to, if any. [Retrieve a User](#header-retrieve-a-user) omits it when `subaccounts` is non-empty.
+    + subaccounts (array[object]) - The subaccounts the user has access to, and their access level on each. For a full description, see [Subaccount access object](#header-subaccount-access-object). [Retrieve a User](#header-retrieve-a-user) always returns this field, as an empty array for a user with no subaccount access, and omits the top-level `access_level` when it is non-empty. [List Users](#header-list-users) returns it only for subaccount-scoped users.
     + options (object) - User-level options, present only when set.
-    + created (string) - ISO 8601 timestamp of when the user was created.
-    + updated (string) - ISO 8601 timestamp of when the user was last updated.
-    + subaccounts (array[object]) - The subaccounts the user has access to, and their access level on each. Always present, and an empty array for a user with no subaccount access. When it is non-empty, the top-level `access_level` and `subaccount_id` fields are omitted. For a full description, see [Subaccount access object](#header-subaccount-access-object).
+    + created (string) - ISO 8601 timestamp of when the user was created. Returned by [Retrieve a User](#header-retrieve-a-user) only.
+    + updated (string) - ISO 8601 timestamp of when the user was last updated. Returned by [Retrieve a User](#header-retrieve-a-user) only.
 
 ### Subaccount access object
 
@@ -303,20 +270,22 @@ Returns the users on your account.
         {
             "results": [
                 {
-                    "name": "Ada Lovelace",
                     "username": "ada",
+                    "first_name": "Ada",
+                    "last_name": "Lovelace",
                     "email": "ada@example.com",
-                    "access": "admin",
+                    "access_level": "admin",
                     "is_sso": false,
                     "email_verified": true,
                     "tfa_enabled": false,
                     "last_login": "2026-07-28T14:22:31.000Z"
                 },
                 {
-                    "name": "Katherine Johnson",
                     "username": "katherine",
+                    "first_name": "Katherine",
+                    "last_name": "Johnson",
                     "email": "katherine@example.com",
-                    "access": "custom",
+                    "access_level": "custom",
                     "access_policies": [
                         "templates/full",
                         "events/read",
@@ -342,7 +311,7 @@ Returns the users on your account.
 
 ### Retrieve a User [GET /v1/users/{username}]
 
-Returns one user by username, in the [Retrieved user object](#header-retrieved-user-object) shape.
+Returns one user by username, in the [User object](#header-user-object) shape.
 
 + Parameters
     + username (required, string, `grace`) - The username of the user to retrieve.
@@ -366,6 +335,7 @@ Returns one user by username, in the [Retrieved user object](#header-retrieved-u
                 "is_sso": false,
                 "email_verified": true,
                 "tfa_enabled": true,
+                "last_login": "2026-08-02T09:14:05.000Z",
                 "created": "2015-01-11T08:00:00.000Z",
                 "updated": "2018-04-11T08:00:00.000Z",
                 "subaccounts": []
@@ -385,6 +355,7 @@ Returns one user by username, in the [Retrieved user object](#header-retrieved-u
                 "is_sso": false,
                 "email_verified": true,
                 "tfa_enabled": false,
+                "last_login": null,
                 "created": "2015-01-11T08:00:00.000Z",
                 "updated": "2018-04-11T08:00:00.000Z",
                 "subaccounts": [

--- a/content/api/users.apib
+++ b/content/api/users.apib
@@ -278,7 +278,7 @@ Revokes a pending invitation. Its registration link stops working immediately.
         {
             "errors": [
                 {
-                    "message": "User invite ID does not exist"
+                    "message": "Resource could not be found"
                 }
             ]
         }
@@ -403,7 +403,7 @@ Returns one user by username, in the [User object](#header-user-object) shape.
         {
             "errors": [
                 {
-                    "message": "User not found."
+                    "message": "Resource could not be found"
                 }
             ]
         }
@@ -502,7 +502,7 @@ Deletes a user from your account.
         {
             "errors": [
                 {
-                    "message": "User does not exist"
+                    "message": "Resource could not be found"
                 }
             ]
         }

--- a/content/api/users.apib
+++ b/content/api/users.apib
@@ -10,7 +10,7 @@ The Users API lets you list, invite, update, and remove the users on your accoun
 
 To call the Users API, an API key must hold one of two grants, and an **admin** must attach the grant to the key through the web app's [API Keys page](https://app.sparkpost.com/account/api-keys). A grant cannot be attached by another API key. Both are `api_key`-role grants.
 
-* **`Users: View`** — read-only access, covering the `GET` endpoints only: [List Users](#header-list-users), [Retrieve a User](#header-retrieve-a-user), [List Pending Invites](#header-list-pending-invites), and [List a User's Subaccounts](#header-list-a-users-subaccounts).
+* **`Users: View`** — read-only access, covering the `GET` endpoints only: [List Users](#header-list-users), [Retrieve a User](#header-retrieve-a-user), and [List Pending Invites](#header-list-pending-invites).
 * **`Users: Manage`** — full management. Every write endpoint (invite, update, delete, and the subaccount-mapping changes) requires this grant.
 
 Requests made with a key that holds neither grant, or that attempt a write with only `Users: View`, are rejected with `403 Forbidden`.
@@ -58,6 +58,17 @@ Returned by [List Users](#header-list-users) and [Retrieve a User](#header-retri
     + email_verified (boolean) - Whether the user has verified their email address.
     + tfa_enabled (boolean) - Whether the user has two-factor authentication enabled.
     + subaccount_id (number) - The subaccount the user is scoped to, if any.
+    + subaccounts (array) - The subaccounts a subaccount-scoped user has access to, and their access level on each. Present only for subaccount-scoped users; when it is present, the top-level `access` and `subaccount_id` fields are omitted.
+        + (object)
+            + subaccount_id (number) - The subaccount ID.
+            + subaccount_name (string) - The subaccount's display name.
+            + access_level (enum) - The user's access level on the subaccount.
+                + `subaccount_reporting`
+                + `subaccount_developer`
+            + status (enum) - The subaccount's status. Returned only by [Retrieve a User](#header-retrieve-a-user).
+                + active
+                + suspended
+                + terminated
     + options (object) - User-level options, present only when set.
 
 ### Invite object
@@ -133,6 +144,8 @@ Returns the users on your account.
 
 Returns a single user by username.
 
+For a subaccount-scoped user, the response embeds a `subaccounts` array describing the subaccounts the user can access and their access level on each. When `subaccounts` is present, the top-level `access` and `subaccount_id` fields are omitted.
+
 + Parameters
     + username (required, string, `grace`) - The username of the user to retrieve.
 
@@ -154,6 +167,29 @@ Returns a single user by username.
                 "is_sso": false,
                 "email_verified": true,
                 "tfa_enabled": true
+            }
+        }
+
++ Response 200 (application/json)
+
+    A subaccount-scoped user.
+
+        {
+            "results": {
+                "name": "Joe Mechanic",
+                "username": "joe",
+                "email": "joe@example.com",
+                "is_sso": false,
+                "email_verified": true,
+                "tfa_enabled": false,
+                "subaccounts": [
+                    {
+                        "subaccount_id": 123,
+                        "subaccount_name": "Joe's Garage",
+                        "access_level": "subaccount_reporting",
+                        "status": "active"
+                    }
+                ]
             }
         }
 
@@ -403,33 +439,6 @@ You cannot delete the user who owns the API key you are calling with, a user tha
             "errors": [
                 {
                     "message": "User does not exist"
-                }
-            ]
-        }
-
-### List a User's Subaccounts [GET /v1/users/{username}/subaccounts]
-
-Returns the subaccounts a user has been granted access to, along with their access level on each.
-
-+ Parameters
-    + username (required, string, `grace`) - The username of the user.
-
-+ Request
-
-    + Headers
-
-            Authorization: 14ac5499cfdd2bb2859e4476d2e5b1d2bad079bf
-            Accept: application/json
-
-+ Response 200 (application/json)
-
-        {
-            "results": [
-                {
-                    "subaccount_id": 123,
-                    "subaccount_name": "Joe's Garage",
-                    "access_level": "subaccount_reporting",
-                    "status": "active"
                 }
             ]
         }

--- a/content/api/users.apib
+++ b/content/api/users.apib
@@ -161,6 +161,16 @@ Invitations expire after three days. The registration link then stops working an
 
 To give someone another chance to register, [invite the same email address again](#header-invite-a-user). That creates a second, independent invitation with its own expiry, and the first one keeps working until it expires or you [revoke it](#header-revoke-a-pending-invite).
 
+### Accounts with single sign-on
+
+On an account with SAML single sign-on enabled, [Invite a User](#header-invite-a-user) skips the invitation. There is no password to set, so the user is created at once with `is_sso` true, and the email tells them to sign in through your identity provider. This changes what the call returns and what you can do afterwards:
+
+- The response carries the new `username` instead of an invite `id`.
+- Nothing appears in [List Pending Invites](#header-list-pending-invites), and there is nothing to revoke. To take the access back, [delete the user](#header-delete-a-user).
+- Inviting an address that already belongs to a user returns `200` with that user's `username`.
+
+Someone outside your identity provider, such as a client who only needs a subaccount, can still get a password login. Send `bypass_sso: true` together with `subaccounts`, and the call creates a regular invitation with a registration link. `bypass_sso` is rejected on a primary-account invite.
+
 ### Invite a User [POST /v1/users/invite]
 
 Creates an invitation and emails a registration link to the address you supply. The invitee follows the link, sets their own password, and takes the role you named in `access_level`.
@@ -178,6 +188,7 @@ The response contains the invite `id`, which you use to [list](#header-list-pend
         + `custom`
     + `access_policies` (array[string]) - The [access policies](#header-access-policies) to grant. Only valid when `access_level` is `custom`.
     + subaccounts (array[object]) - Invite the user with access to one or more subaccounts instead of the primary account. Between 1 and 25 entries. For a full description, see [Subaccount invite object](#header-subaccount-invite-object).
+    + bypass_sso (boolean) - On an account with single sign-on, create a regular invitation with a registration link instead of an SSO user. Only valid together with `subaccounts`. See [Accounts with single sign-on](#header-accounts-with-single-sign-on).
 
 
 + Request (application/json)
@@ -198,6 +209,16 @@ The response contains the invite `id`, which you use to [list](#header-list-pend
         {
             "results": {
                 "id": "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+            }
+        }
+
++ Response 200 (application/json)
+
+    On an account with single sign-on. See [Accounts with single sign-on](#header-accounts-with-single-sign-on).
+
+        {
+            "results": {
+                "username": "newuser"
             }
         }
 

--- a/content/api/users.apib
+++ b/content/api/users.apib
@@ -54,7 +54,7 @@ Every user is scoped either to the account or to one or more subaccounts. An acc
     + first_name (string, nullable) - The user's first name.
     + last_name (string, nullable) - The user's last name.
     + email (string) - The user's email address.
-    + access_level (enum) - The user's role on the account. Absent for subaccount-scoped users.
+    + access_level (enum) - The user's [role](#header-roles) on the account. Absent for subaccount-scoped users.
         + `admin`
         + `developer`
         + `reporting`
@@ -118,12 +118,14 @@ Returned by [List Pending Invites](#header-list-pending-invites).
     + id (string) - Unique ID for the pending invite. Use it to revoke the invite.
     + email (string) - The email address the invite was sent to.
     + from (string) - The email address of the user who created the invite.
-    + access_level (enum) - The role the user takes on when they register.
+    + access_level (enum) - The [role](#header-roles) the user takes on when they register.
         + `admin`
         + `developer`
         + `reporting`
         + `templates`
         + `custom`
+    + `access_policies` (array[string]) - The [access policies](#header-access-policies) the user takes on when they register, if `access_level` is `custom`.
+    + subaccounts (array[object]) - The subaccount access the user takes on when they register. See [Subaccount invite object](#header-subaccount-invite-object). Present instead of `access_level` for a subaccount-scoped invite.
     + expires (number) - Unix timestamp, in epoch seconds, at which the invitation expires.
 + Sample
     ```
@@ -169,7 +171,7 @@ The response contains the invite `id`, which you use to [list](#header-list-pend
 
 + Data Structure
     + email (string, required) - Email address of the person to invite. Maximum 512 characters.
-    + access_level (enum) - The primary-account role to assign. Required unless `subaccounts` is supplied. `admin` is not available to API keys.
+    + access_level (enum) - The primary-account [role](#header-roles) to assign. Required unless `subaccounts` is supplied. `admin` is not available to API keys.
         + `developer`
         + `reporting`
         + `templates`

--- a/content/api/users.apib
+++ b/content/api/users.apib
@@ -483,6 +483,16 @@ Returns one user by username, in the [User object](#header-user-object) shape.
             ]
         }
 
++ Response 403 (application/json)
+
+        {
+            "errors": [
+                {
+                    "message": "Admin-level access cannot be granted through the API."
+                }
+            ]
+        }
+
 ### Delete a User [DELETE /v1/users/{username}]
 
 Deletes a user from your account.


### PR DESCRIPTION
## Summary

Adds a public API reference page for the **Users API**: the endpoints reachable by the `api_key`-role user-management grants that let an API key manage the users on an account.

New page `content/api/users.apib`, registered under the **Accounts** category in `content/api/table-of-contents.json` (after `subaccounts.apib`).

Everything in the `.apib` is public. Implementation-internal details are kept out of the page and captured in **Reviewer notes** below instead.

## Preview

https://deploy-preview-586--developers-sparkpost.netlify.app/api/users/

### Endpoints documented

- `GET /api/v1/users` — list users
- `GET /api/v1/users/:username` — retrieve a user
- `POST /api/v1/users/invite` — invite a user (creation is invite-based only)
- `GET /api/v1/users/pending-invites` — list pending invites (canonical path)
- `DELETE /api/v1/users/pending-invites/:id` — revoke a pending invite
- `PUT /api/v1/users/:username` — update a user
- `DELETE /api/v1/users/:username` — delete a user
- `POST /api/v1/users/:username/subaccounts` / `DELETE /api/v1/users/:username/subaccounts/:subaccountId` — manage subaccount mappings

The read-side `GET /api/v1/users/:username/subaccounts` endpoint was **dropped per design review** (accusers-api `9a1ca17ce`); a user's subaccount access is documented instead as the `subaccounts` array embedded in user objects.

### Also covered

- **Prerequisites / grants.** A key needs one of two `api_key`-role grants, attached by an **admin** from the web app and never by another API key: **`Users: View`** for the three `GET` endpoints, or **`Users: Manage`** for the same reads plus every write. No account-option or support-enablement step is documented; see the GA rollout note under Reviewer notes.
- **Constraints.** An API key can never assign `admin`, even when an admin owns it. Below admin, the role ceiling still applies. The last admin cannot be deleted or demoted. A key cannot delete its own owner.
- **Invite semantics and lifecycle.** Creation is invite-based only. The response returns the invite `id` and nothing else: the registration token is never returned to any caller. Invitations expire after 3 days, expired invites drop off the pending list automatically, there is no resend, and invite creation is rate limited (`429`).
- **Update is role-only.** `PUT` accepts `access_level` and `access_policies` and rejects any other field with `403`.
- **Subaccount mapping rules.** `POST .../subaccounts` requires the target to already hold at least one mapping; `DELETE .../subaccounts/:id` refuses to remove the last one. Both `400`s are documented.
- Two-factor, email-verification, SCIM, and password endpoints are out of scope.

## Verified against the code

Every endpoint, field, response shape, and error body on the page was checked against the `feat/users-manage-programmatic` branches of accusers-api and access, including the uncommitted `lib/errors.js` refactor that sets the current `userMessage` strings.

Checked: route registrations (`resources/user-endpoints.js`), the grant definitions and labels (`@sparkpost/access` `lib/token-access.js`), the response shapes (`lib/models/users.js` `formatUser` and `getUserByUsername`, `resources/user-controller.js` `lookUpUser`), the invite listing fields (`lib/models/helpers/invite-dynamo.js`), and every validator behind the documented status codes.

### Corrections made in this PR after re-verification

- **Invite no longer returns the token.** accusers-api `086008f1f` stopped returning it from `POST /users/invite` for all callers. The earlier revision of this page documented `token` in the response and carried a "treat the token as a credential" banner. Both are gone.
- **API keys cannot assign `admin`.** The programmatic cap in `lib/access/role-ceiling.js` and `lib/validator/edit-user-validator.js` rejects admin on invite, create, and `PUT`, even for an admin-owned key. The earlier revision said an admin-owned key could assign up to `admin`. Now its own constraint, and `admin` is dropped from the invite and update request enums.
- **Dropped the key-revocation constraint.** Reverted in `5b1dbdee5`: API keys are account-owned and get reassigned to another admin on owner deletion, not revoked.
- **Documented the two subaccount-mapping `400`s** (`has-account-subaccount-access`, `last-subaccount-check`), neither of which was on the page.
- **Real error bodies.** Placeholder `"Forbidden"` bodies replaced with the `userMessage` strings the service sends. The Retrieve 404 is `"User not found."` (`userNotFoundOptions`), not the delete validator's `"User does not exist"`.
- **`access` is omitted, not empty**, for subaccount-scoped users: a subaccounts-only invite never sets `access_level` on the user record.
- **`last_login` documented** on the List Users object (ISO string or `null`, per `lib/validator/auth0-post-login-action.js`). This closes the open question from the earlier revision.
- **`access_policies` on `PUT` is optional** when `access_level` is `custom`, not required (`areValidPolicies` only forbids it for non-custom roles).

## Reviewer notes (not in public docs)

- **GA rollout / no option-gate wording.** The page is slated to publish at GA, after the account-option gate is removed, so it omits any "contact support to enable" step. Both grants still carry `option: 'allow_user_management_via_api'` in the access branch; that gate is expected to be gone by publish time.
- **Invite rate-limit internals.** The `429` comes from `inviteThrottle` (`config.emailThrottling.invite`): `maxPerRecipient` 3, `maxPerRequester` 20, over a 3600s window. The public page omits the numbers.
- **Invite expiry source.** The documented 3-day expiry is `config.emailInvite.ttl` = 259200s. Expired invites are filtered out in `invite-dynamo.getInvites` and reaped by DynamoDB TTL.
- **List vs Retrieve response shapes.** These genuinely differ, and the page documents both as separate objects rather than papering over it.
  - *List item* (`formatUser`): `name`, `username`, `access`, `access_policies`, `email`, `is_sso`, `email_verified`, `tfa_enabled`, `last_login`, `subaccount_id`, `options` (only when set). Mapped users also get `subaccounts: [{subaccount_id, access_level, subaccount_name}]`, with no `status`.
  - *Retrieve* (`getUserByUsername` + `lookUpUser`): `first_name`/`last_name` instead of `name`, `access_level` instead of `access` (omitted for subaccount-scoped users), plus `created`, `updated`, and an always-present `subaccounts` array (`{subaccount_id, subaccount_name, access_level, status}`). Top-level `access_level` and `subaccount_id` drop out when `subaccounts` is non-empty.
  - The list response also attaches a `link` object per user, and `auth_migrated`. Neither is documented.

### :warning: One open item for the implementation

`lookUpUser` applies no grant-scoped field filtering. A programmatic `GET /users/:username` currently returns `customer`, `cookie_consent`, `tou`, `tou_auto_accept`, `creation_params`, `auth_migrated`, `auth_connection`, `tokens` (API-key IDs, not secrets), and `customer_id` inside each `subaccounts` entry. The page deliberately documents only the supported subset, so publishing as-is is fine, but **someone should decide whether the programmatic response ought to be trimmed** before GA.

## :warning: Do not merge/publish until the feature ships

This documents an unreleased feature. Hold until the implementation ships:
- SparkPost/access#124 (grants, `@sparkpost/access` 4.13.0)
- SparkPost/accusers-api#1294 (endpoint hardening)
- SparkPost/auth-api#319 (grant enforcement)

Closes #584
Part of SparkPost/access#121


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or auth behavior in this repo; publish timing should stay aligned with the unreleased Users API rollout.
> 
> **Overview**
> Adds a new **Users API** reference (`users.apib`, labeled **New**) and registers it in the **Accounts** section of `table-of-contents.json` (after subaccounts).
> 
> The page documents programmatic account user management: roles and custom `access_policies`, invite lifecycle (including SSO immediate-create vs email invite, `bypass_sso` for subaccount invites), listing/retrieving users, role-only updates, deletion, and subaccount access grant/revoke. It spells out API limits such as no `admin` via API, last-admin protection, invite rate limiting, and subaccount-mapping constraints. Subaccount membership is described on the user object rather than a separate list endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46cc1ec2bcc232ea00d02d87d7a1a468a8852392. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->