### PR TITLE
docs: document subaccount open_tracking_disabled option

### DIFF
--- a/content/api/subaccounts.apib
+++ b/content/api/subaccounts.apib
@@ -117,6 +117,8 @@ If your result set is less than one page of data, then the `links` object will n
     + options (object)
         + deliverability (boolean) 
             <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Whether the subaccount has access to deliverability features.
+        + open_tracking_disabled (boolean)
+            When `true`, open tracking is disabled for this subaccount: no open-tracking pixels are injected into its future mail. Click tracking is unaffected. Defaults to `false`.
 
 + Sample
     
@@ -159,6 +161,8 @@ Subaccounts are allowed to send mail using the SMTP protocol or Transmissions AP
     + options (object) - subaccount-level options.
         + deliverability (boolean)
             <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Whether the subaccount has access to deliverability features.
+        + open_tracking_disabled (boolean)
+            When `true`, open tracking is disabled for this subaccount: no open-tracking pixels are injected into its future mail. Click tracking is unaffected. Defaults to `false`.
             
 Returns the subaccount's ID, along with the API key and API key label, if one was created.
 
@@ -284,6 +288,8 @@ This endpoint only returns information about the subaccount, not the resources a
     + options (object) - subaccount-level options.
         + deliverability (boolean)
             <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Whether the subaccount has access to deliverability features.
+        + open_tracking_disabled (boolean)
+            When `true`, open tracking is disabled for this subaccount: no open-tracking pixels are injected into its future mail. Click tracking is unaffected. Defaults to `false`.
 
 
 + Parameters

--- a/content/api/subaccounts.apib
+++ b/content/api/subaccounts.apib
@@ -118,7 +118,7 @@ If your result set is less than one page of data, then the `links` object will n
         + deliverability (boolean) 
             <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Whether the subaccount has access to deliverability features.
         + open_tracking_disabled (boolean)
-            When `true`, open tracking is disabled for this subaccount: no open-tracking pixels are injected into its future mail. Click tracking is unaffected. Defaults to `false`.
+            When `true`, open tracking is disabled for this subaccount: no open-tracking pixels are injected into its future mail, and no open events are generated for pixels already delivered in its past mail (the pixel is still served). Click tracking is unaffected. Defaults to `false`.
 
 + Sample
     
@@ -162,7 +162,7 @@ Subaccounts are allowed to send mail using the SMTP protocol or Transmissions AP
         + deliverability (boolean)
             <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Whether the subaccount has access to deliverability features.
         + open_tracking_disabled (boolean)
-            When `true`, open tracking is disabled for this subaccount: no open-tracking pixels are injected into its future mail. Click tracking is unaffected. Defaults to `false`.
+            When `true`, open tracking is disabled for this subaccount: no open-tracking pixels are injected into its future mail, and no open events are generated for pixels already delivered in its past mail (the pixel is still served). Click tracking is unaffected. Defaults to `false`.
             
 Returns the subaccount's ID, along with the API key and API key label, if one was created.
 
@@ -289,7 +289,7 @@ This endpoint only returns information about the subaccount, not the resources a
         + deliverability (boolean)
             <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Whether the subaccount has access to deliverability features.
         + open_tracking_disabled (boolean)
-            When `true`, open tracking is disabled for this subaccount: no open-tracking pixels are injected into its future mail. Click tracking is unaffected. Defaults to `false`.
+            When `true`, open tracking is disabled for this subaccount: no open-tracking pixels are injected into its future mail, and no open events are generated for pixels already delivered in its past mail (the pixel is still served). Click tracking is unaffected. Defaults to `false`.
 
 
 + Parameters

--- a/content/api/subaccounts.apib
+++ b/content/api/subaccounts.apib
@@ -118,7 +118,7 @@ If your result set is less than one page of data, then the `links` object will n
         + deliverability (boolean) 
             <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Whether the subaccount has access to deliverability features.
         + open_tracking_disabled (boolean)
-            When `true`, open tracking is disabled for this subaccount: no open-tracking pixels are injected into its future mail, and no open events are generated for pixels already delivered in its past mail (the pixel is still served). Click tracking is unaffected. Defaults to `false`.
+            When `true`, open tracking is disabled for this subaccount: no open-tracking pixels are injected into its future mail, and no open events are generated for pixels already delivered in its past mail (the pixel is still served). This is a hard override: it takes precedence over any per-template, per-transmission, or per-recipient open-tracking setting, so a message that explicitly requests open tracking is still not tracked for a disabled subaccount. Click tracking is unaffected. Defaults to `false`.
 
 + Sample
     
@@ -162,7 +162,7 @@ Subaccounts are allowed to send mail using the SMTP protocol or Transmissions AP
         + deliverability (boolean)
             <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Whether the subaccount has access to deliverability features.
         + open_tracking_disabled (boolean)
-            When `true`, open tracking is disabled for this subaccount: no open-tracking pixels are injected into its future mail, and no open events are generated for pixels already delivered in its past mail (the pixel is still served). Click tracking is unaffected. Defaults to `false`.
+            When `true`, open tracking is disabled for this subaccount: no open-tracking pixels are injected into its future mail, and no open events are generated for pixels already delivered in its past mail (the pixel is still served). This is a hard override: it takes precedence over any per-template, per-transmission, or per-recipient open-tracking setting, so a message that explicitly requests open tracking is still not tracked for a disabled subaccount. Click tracking is unaffected. Defaults to `false`.
             
 Returns the subaccount's ID, along with the API key and API key label, if one was created.
 
@@ -289,7 +289,7 @@ This endpoint only returns information about the subaccount, not the resources a
         + deliverability (boolean)
             <a href="https://www.sparkpost.com/features/email-deliverability/"><span class="label label-warning">Deliverability Add-On</span></a> Whether the subaccount has access to deliverability features.
         + open_tracking_disabled (boolean)
-            When `true`, open tracking is disabled for this subaccount: no open-tracking pixels are injected into its future mail, and no open events are generated for pixels already delivered in its past mail (the pixel is still served). Click tracking is unaffected. Defaults to `false`.
+            When `true`, open tracking is disabled for this subaccount: no open-tracking pixels are injected into its future mail, and no open events are generated for pixels already delivered in its past mail (the pixel is still served). This is a hard override: it takes precedence over any per-template, per-transmission, or per-recipient open-tracking setting, so a message that explicitly requests open tracking is still not tracked for a disabled subaccount. Click tracking is unaffected. Defaults to `false`.
 
 
 + Parameters


### PR DESCRIPTION
## Summary

Documents the new subaccount `open_tracking_disabled` option (knowledge-base#46) in the Subaccounts API — added to the subaccount object and to the create and update request bodies (all three `options` blocks).

Describes the complete feature: `true` ⇒ no open-tracking pixels injected into the subaccount's future mail (send-side, Momentum) **and** no open events generated for pixels already delivered in its past mail, the pixel still being served (event-side, link-tracker-api). Click tracking is unaffected; default `false`.

**Merge last:** hold until the full feature — send-side (Momentum#1533) and event-side (link-tracker-api#261) — is QA'd in prd, so the published docs never describe behavior ahead of what's live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only API Blueprint changes with no runtime or security impact.
> 
> **Overview**
> Documents **`options.open_tracking_disabled`** on the Subaccounts API in **`subaccounts.apib`**: the subaccount resource schema plus create and update request bodies.
> 
> When **`true`**, the docs state that open tracking is fully off for that subaccount—no pixels on future sends and no open events for existing pixels (pixels still load)—and that this **overrides** template, transmission, and recipient open-tracking settings. **Click tracking is unchanged**; default **`false`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 636d75b654938a153222b3e3062e0f0d50bc9d9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->